### PR TITLE
#67 (ZF-12549) copyObject() no longer overrides Content-Type

### DIFF
--- a/library/Zend/Service/Rackspace/Abstract.php
+++ b/library/Zend/Service/Rackspace/Abstract.php
@@ -329,6 +329,11 @@ abstract class Zend_Service_Rackspace_Abstract
     {
         $client = $this->getHttpClient();
         $client->resetParameters(true);
+        if ($method == 'PUT' && empty($body)) {
+            // if left at NULL a PUT request will always have 
+            // Content-Type: x-url-form-encoded, which breaks copyObject()
+            $client->setEncType(''); 
+        }
         if (empty($headers[self::AUTHUSER_HEADER])) {
             $headers[self::AUTHTOKEN]= $this->getToken();
         } 

--- a/tests/Zend/Service/Rackspace/Files/OfflineTest.php
+++ b/tests/Zend/Service/Rackspace/Files/OfflineTest.php
@@ -212,6 +212,7 @@ class Zend_Service_Rackspace_Files_OfflineTest
             'zf-object-test' . '-copy'
         );
         $this->assertTrue($result);
+        $this->assertNotContains('application/x-www-form-urlencoded', $this->rackspace->getHttpClient()->getLastRequest());
     }
 
     public function testGetObjects()


### PR DESCRIPTION
Fix + test to stop copying Rackspace Cloud Files objects overriding content type.
