### PR TITLE
Fixed #68 (ZF-12552) getObjects() can now list psuedo-directories

### DIFF
--- a/library/Zend/Service/Rackspace/Files/Object.php
+++ b/library/Zend/Service/Rackspace/Files/Object.php
@@ -94,39 +94,45 @@ class Zend_Service_Rackspace_Files_Object
             require_once 'Zend/Service/Rackspace/Files/Exception.php';
             throw new Zend_Service_Rackspace_Files_Exception("You must pass a RackspaceFiles and an array");
         }
-        if (!array_key_exists('name', $data)) {
-            require_once 'Zend/Service/Rackspace/Files/Exception.php';
-            throw new Zend_Service_Rackspace_Files_Exception("You must pass the name of the object in the array (name)");
-        }
         if (!array_key_exists('container', $data)) {
             require_once 'Zend/Service/Rackspace/Files/Exception.php';
             throw new Zend_Service_Rackspace_Files_Exception("You must pass the container of the object in the array (container)");
         }
-        if (!array_key_exists('hash', $data)) {
-            require_once 'Zend/Service/Rackspace/Files/Exception.php';
-            throw new Zend_Service_Rackspace_Files_Exception("You must pass the hash of the object in the array (hash)");
+        if (array_key_exists('name', $data)) {
+            if (!array_key_exists('hash', $data)) {
+                require_once 'Zend/Service/Rackspace/Files/Exception.php';
+                throw new Zend_Service_Rackspace_Files_Exception("You must pass the hash of the object in the array (hash)");
+            }
+            if (!array_key_exists('bytes', $data)) {
+                require_once 'Zend/Service/Rackspace/Files/Exception.php';
+                throw new Zend_Service_Rackspace_Files_Exception("You must pass the byte size of the object in the array (bytes)");
+            }
+            if (!array_key_exists('content_type', $data)) {
+                require_once 'Zend/Service/Rackspace/Files/Exception.php';
+                throw new Zend_Service_Rackspace_Files_Exception("You must pass the content type of the object in the array (content_type)");
+            }
+            if (!array_key_exists('last_modified', $data)) {
+                require_once 'Zend/Service/Rackspace/Files/Exception.php';
+                throw new Zend_Service_Rackspace_Files_Exception("You must pass the last modified data of the object in the array (last_modified)");
+            }
+            $this->name= $data['name'];
+            $this->hash= $data['hash'];
+            $this->size= $data['bytes'];
+            $this->contentType= $data['content_type'];
+            $this->lastModified= $data['last_modified'];
+            if (!empty($data['content'])) {
+                $this->content= $data['content'];
+            }
         }
-        if (!array_key_exists('bytes', $data)) {
-            require_once 'Zend/Service/Rackspace/Files/Exception.php';
-            throw new Zend_Service_Rackspace_Files_Exception("You must pass the byte size of the object in the array (bytes)");
+        elseif (array_key_exists('subdir', $data)) {
+            $this->name = $data['subdir'];
         }
-        if (!array_key_exists('content_type', $data)) {
+        else {
             require_once 'Zend/Service/Rackspace/Files/Exception.php';
-            throw new Zend_Service_Rackspace_Files_Exception("You must pass the content type of the object in the array (content_type)");
+            throw new Zend_Service_Rackspace_Files_Exception("You must pass the name of the object in the array (name)");
         }
-        if (!array_key_exists('last_modified', $data)) {
-            require_once 'Zend/Service/Rackspace/Files/Exception.php';
-            throw new Zend_Service_Rackspace_Files_Exception("You must pass the last modified data of the object in the array (last_modified)");
-        }
-        $this->name= $data['name'];
+        
         $this->container= $data['container'];
-        $this->hash= $data['hash'];
-        $this->size= $data['bytes'];
-        $this->contentType= $data['content_type'];
-        $this->lastModified= $data['last_modified'];
-        if (!empty($data['content'])) {
-            $this->content= $data['content'];
-        }
         $this->service= $service;
     }
     /**

--- a/tests/Zend/Service/Rackspace/Files/OfflineTest.php
+++ b/tests/Zend/Service/Rackspace/Files/OfflineTest.php
@@ -222,6 +222,15 @@ class Zend_Service_Rackspace_Files_OfflineTest
         $this->assertEquals($objects[0]->getName(), 'zf-object-test');
         $this->assertEquals($objects[1]->getName(), 'zf-object-test' . '-copy');
     }
+    
+    public function testGetObjectsPseudoDirs()
+    {
+        $objects = $this->rackspace->getObjects('zf-unit-test', array('delimiter' => '/', 'prefix' => 'dir/'));
+        $this->assertTrue($objects !== false);
+
+        $this->assertEquals($objects[0]->getName(), 'dir/subdir1/');
+        $this->assertEquals($objects[1]->getName(), 'dir/subdir2/');
+    }
 
     public function testGetSizeContainers()
     {

--- a/tests/Zend/Service/Rackspace/Files/_files/testGetObjectsPseudoDirs.response
+++ b/tests/Zend/Service/Rackspace/Files/_files/testGetObjectsPseudoDirs.response
@@ -1,0 +1,12 @@
+HTTP/1.1 200 OK
+X-Timestamp: 1340815553.90579
+Content-Type: application/json; charset=utf-8
+Date: Mon, 25 Mar 2013 16:00:03 GMT
+X-Container-Bytes-Used: 22
+X-Container-Object-Count: 2
+Accept-Ranges: bytes
+X-Trans-Id: tx1f63df08fcc646a5874388de8f197b72
+Connection: close
+Content-Length: 56
+
+[{"subdir": "dir/subdir1/"}, {"subdir": "dir/subdir2/"}]


### PR DESCRIPTION
Fix + test to allow Zend_Service_Rackspace_Files to list psuedo directories. For instance:

```
$cf->getObjects('mycontainer', array('delimiter' => '/', 'prefix' => 'path/to/mydir/');
```

Previously this would throw an exception.
