### PR TITLE
Support setters that work on references in forms and elements

### DIFF
--- a/library/Zend/Form.php
+++ b/library/Zend/Form.php
@@ -363,7 +363,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
             'Attrib', 'Default',
         );
 
-        foreach ($options as $key => $value) {
+        foreach ($options as $key => & $value) {
             $normalized = ucfirst($key);
             if (in_array($normalized, $forbidden)) {
                 continue;
@@ -378,6 +378,8 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
             } else {
                 $this->setAttrib($key, $value);
             }
+
+            unset($key, $value);
         }
 
         if (isset($displayGroupDecorators)) {

--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -361,7 +361,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
         unset($options['options']);
         unset($options['config']);
 
-        foreach ($options as $key => $value) {
+        foreach ($options as $key => & $value) {
             $method = 'set' . ucfirst($key);
 
             if (in_array($method, array('setTranslator', 'setPluginLoader', 'setView'))) {
@@ -377,6 +377,8 @@ class Zend_Form_Element implements Zend_Validate_Interface
                 // Assume it's metadata
                 $this->setAttrib($key, $value);
             }
+
+            unset($key, $value);
         }
         return $this;
     }


### PR DESCRIPTION
When passing array of options to constructor (or directly to `setOptions` method) containing references that should be set by setter with reference in it's params definition, references were not preserved.

Better explained by example:

Setter in form class:

``` php
public function setFoo(& $foo) {
    $this->_foo =& $foo;
}
```

Then:

``` php
$foo = 42;
$form->setFoo($foo);
$foo = 13;
echo $form->getFoo(); // 13

// but

$foo = 42;
$form = new AForm(array('foo' => & $foo));
$foo = 13;
echo $form->getFoo(); // 42
```
