### PR TITLE
Replace PCRE /e modifier with preg_replace_callback() - PHP 5.5

### DIFF
--- a/library/Zend/Ldap/Converter.php
+++ b/library/Zend/Ldap/Converter.php
@@ -69,7 +69,9 @@ class Zend_Ldap_Converter
      */
     public static function hex32ToAsc($string)
     {
-        $string = preg_replace("/\\\([0-9A-Fa-f]{2})/e", "''.chr(hexdec('\\1')).''", $string);
+        $string = preg_replace_callback('/\\\([0-9A-Fa-f]{2})/', function ($matches) {
+            return chr(hexdec($matches[1]));
+        }, $string);
         return $string;
     }
 


### PR DESCRIPTION
Replaced usage of preg_replace with "/e" modifier with
  preg_replace_callback() using a closure
