### PR TITLE
Fixes Ticket #59 - Zend_Mail function _formatAddress not following RFC2822

### DIFF
--- a/library/Zend/Mail.php
+++ b/library/Zend/Mail.php
@@ -1264,7 +1264,7 @@ class Zend_Mail extends Zend_Mime_Message
             return $email;
         } else {
             $encodedName = $this->_encodeHeader($name);
-            if ($encodedName === $name  &&  strcspn($name, '()<>[]:;@\\,') != strlen($name)) {
+            if ($encodedName === $name  &&  strcspn($name, '()<>[]:;@\\,.') != strlen($name)) {
                 $format = '"%s" <%s>';
             } else {
                 $format = '%s <%s>';


### PR DESCRIPTION
Add dot to the list.
