### PR TITLE
Explicit preffixed namespace in config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "autoload": {
         "psr-0": {
-            "Zend": "library/"
+            "Zend_": "library/"
         }
     },
     "include-path": [


### PR DESCRIPTION
Explicit preffixed namespace in config

As described on http://getcomposer.org/doc/04-schema.md#autoload

> Please note namespace declarations should end in \ to make sure the autoloader responds exactly. For example Foo would match in FooBar so the trailing backslashes solve the problem: Foo\ and FooBar\ are distinct.

Without this fix next code throws 'Cannot redeclare Zend_Registry' error

``` php
class_exists('\Zend\Registry')
```
