### PR TITLE
Fixes #16 - Zend_Validate_Hostname doesn't handle IDN for .UA

### DIFF
--- a/library/Zend/Validate/Hostname.php
+++ b/library/Zend/Validate/Hostname.php
@@ -186,6 +186,7 @@ class Zend_Validate_Hostname extends Zend_Validate_Abstract
      * (.TH) Thailand http://www.iana.org/domains/idn-tables/tables/th_th-th_1.0.html
      * (.TM) Turkmenistan http://www.nic.tm/TM-IDN-Policy.pdf
      * (.TR) Turkey https://www.nic.tr/index.php
+     * (.UA) Ukraine http://www.iana.org/domains/idn-tables/tables/ua_cyrl_1.2.html
      * (.VE) Venice http://www.iana.org/domains/idn-tables/tables/ve_es_1.0.html
      * (.VN) Vietnam http://www.vnnic.vn/english/5-6-300-2-2-04-20071115.htm#1.%20Introduction
      *
@@ -292,6 +293,7 @@ class Zend_Validate_Hostname extends Zend_Validate_Abstract
         'TM'  => array(1 => '/^[\x{002d}0-9a-zà-öø-ÿāăąćĉċčďđēėęěĝġģĥħīįĵķĺļľŀłńņňŋőœŕŗřśŝşšţťŧūŭůűųŵŷźżž]{1,63}$/iu'),
         'TW'  => 'Zend/Validate/Hostname/Cn.php',
         'TR'  => array(1 => '/^[\x{002d}0-9a-zğıüşöç]{1,63}$/iu'),
+        'UA'  => array(1 => '/^[\x{002d}0-9a-zабвгдежзийклмнопрстуфхцчшщъыьэюяѐёђѓєѕіїјљњћќѝўџґӂʼ]{1,63}$/iu'),
         'VE'  => array(1 => '/^[\x{002d}0-9a-záéíóúüñ]{1,63}$/iu'),
         'VN'  => array(1 => '/^[ÀÁÂÃÈÉÊÌÍÒÓÔÕÙÚÝàáâãèéêìíòóôõùúýĂăĐđĨĩŨũƠơƯư\x{1EA0}-\x{1EF9}]{1,63}$/iu'),
         'ایران' => array(1 => '/^[\x{0621}-\x{0624}\x{0626}-\x{063A}\x{0641}\x{0642}\x{0644}-\x{0648}\x{067E}\x{0686}\x{0698}\x{06A9}\x{06AF}\x{06CC}\x{06F0}-\x{06F9}]{1,30}$/iu'),

--- a/tests/Zend/Validate/HostnameTest.php
+++ b/tests/Zend/Validate/HostnameTest.php
@@ -423,7 +423,7 @@ class Zend_Validate_HostnameTest extends PHPUnit_Framework_TestCase
             }
         }
     }
-    
+
     /**
      * @group ZF-11334
      * @see http://www.ietf.org/rfc/rfc2732.txt
@@ -431,7 +431,7 @@ class Zend_Validate_HostnameTest extends PHPUnit_Framework_TestCase
     public function testSupportsIpv6AddressesWhichContainHexDigitF()
     {
         $validator = new Zend_Validate_Hostname(Zend_Validate_Hostname::ALLOW_ALL);
-        
+
         $this->assertTrue($validator->isValid('FEDC:BA98:7654:3210:FEDC:BA98:7654:3210'));
         $this->assertTrue($validator->isValid('1080:0:0:0:8:800:200C:417A'));
         $this->assertTrue($validator->isValid('3ffe:2a00:100:7031::1'));
@@ -440,14 +440,14 @@ class Zend_Validate_HostnameTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($validator->isValid('::FFFF:129.144.52.38'));
         $this->assertTrue($validator->isValid('2010:836B:4179::836B:4179'));
     }
-    
+
     /**
      * @group ZF-11796
      */
     public function testIDNSI()
     {
         $validator = new Zend_Validate_Hostname(Zend_Validate_Hostname::ALLOW_ALL);
-        
+
         $this->assertTrue($validator->isValid('Test123.si'));
         $this->assertTrue($validator->isValid('țest123.si'));
         $this->assertTrue($validator->isValid('tĕst123.si'));
@@ -460,6 +460,17 @@ class Zend_Validate_HostnameTest extends PHPUnit_Framework_TestCase
     public function testDKSpecialChars()
     {
         $this->assertTrue($this->_validator->isValid('testæøå.dk'));
+    }
+
+    /**
+     * @ZF-12413
+     */
+    public function testIDNUA()
+    {
+        $validator = new Zend_Validate_Hostname(Zend_Validate_Hostname::ALLOW_ALL);
+
+        $this->assertTrue($validator->isValid('самобраноч.com.ua'));
+        $this->assertTrue($validator->isValid('hostmaster.ua'));
     }
 
 }


### PR DESCRIPTION
related to #16 fixes ZF-12413
