### PR TITLE
Fixes #52

### DIFF
--- a/library/Zend/Mobile/Push/Gcm.php
+++ b/library/Zend/Mobile/Push/Gcm.php
@@ -136,14 +136,6 @@ class Zend_Mobile_Push_Gcm extends Zend_Mobile_Push_Abstract
         $client->setUri(self::SERVER_URI);
         $client->setHeaders('Authorization', 'key=' . $this->getApiKey());
 
-        $json = array('registration_ids' => $message->getToken());
-        if ($data = $message->getData()) {
-            $json['data'] = $data;
-        }
-        if ($id = $message->getId()) {
-            $json['id'] = $id;
-        }
-
         $response = $client->setRawData($message->toJson(), 'application/json')
                            ->request('POST');
         $this->close();

--- a/library/Zend/Mobile/Push/Message/Gcm.php
+++ b/library/Zend/Mobile/Push/Message/Gcm.php
@@ -63,7 +63,7 @@ class Zend_Mobile_Push_Message_Gcm extends Zend_Mobile_Push_Message_Abstract
      * 
      * @var int
      */
-    protected $_ttl = 0;
+    protected $_ttl = 2419200;
 
     /**
      * Add a Token
@@ -199,11 +199,9 @@ class Zend_Mobile_Push_Message_Gcm extends Zend_Mobile_Push_Message_Abstract
     }
 
     /**
-     * Set time to live
-     * If $secs is set to 0 it will be handled as
-     * not being set.
+     * Set time to live.
      *
-     * @param  int $secs
+     * @param int $secs
      * @return Zend_Mobile_Push_Message_Gcm
      */
     public function setTtl($secs)
@@ -236,7 +234,7 @@ class Zend_Mobile_Push_Message_Gcm extends Zend_Mobile_Push_Message_Abstract
         if (!is_array($this->_token) || empty($this->_token)) {
             return false;
         }
-        if ($this->_ttl > 0 &&
+        if ($this->_ttl !== 2419200 &&
             (!is_scalar($this->_id) ||
             strlen($this->_id) === 0)) {
             return false;
@@ -266,7 +264,7 @@ class Zend_Mobile_Push_Message_Gcm extends Zend_Mobile_Push_Message_Abstract
         if ($this->_delay) {
             $json['delay_while_idle'] = $this->_delay;
         }
-        if ($this->_ttl) {
+        if ($this->_ttl !== 2419200) {
             $json['time_to_live'] = $this->_ttl;
         }
         return json_encode($json);


### PR DESCRIPTION
Fixes #52 - Zend_Mobile: GCM time_to_live is not send when set to 0
