### PR TITLE
fix Zend_GData::import and Zend_Gapps::import to match extend

### DIFF
--- a/library/Zend/Gdata.php
+++ b/library/Zend/Gdata.php
@@ -121,7 +121,7 @@ class Zend_Gdata extends Zend_Gdata_App
      *                                    useObjectMapping() function.
      */
     public static function import($uri, $client = null,
-        $className='Zend_Gdata_Feed')
+        $className='Zend_Gdata_Feed', $useObjectMapping = true)
     {
         $app = new Zend_Gdata($client);
         $requestData = $app->decodeRequest('GET', $uri);

--- a/library/Zend/Gdata/Gapps.php
+++ b/library/Zend/Gdata/Gapps.php
@@ -195,10 +195,10 @@ class Zend_Gdata_Gapps extends Zend_Gdata
      * @throws Zend_Gdata_Gapps_ServiceException
      * @return Zend_Gdata_App_Feed
      */
-    public static function import($uri, $client = null, $className='Zend_Gdata_App_Feed')
+    public static function import($uri, $client = null, $className='Zend_Gdata_App_Feed', $useObjectMapping = true)
     {
         try {
-            return parent::import($uri, $client, $className);
+            return parent::import($uri, $client, $className, $useObjectMapping);
         } catch (Zend_Gdata_App_HttpException $e) {
             self::throwServiceExceptionIfDetected($e);
         }


### PR DESCRIPTION
fixes issue #56 

tests are not needed since the existing tests already failed when strict errors are shown. 
