### PR TITLE
Fix lost custom messages in FlashMessenger when no message in default

### DIFF
--- a/library/Zend/Controller/Action/Helper/FlashMessenger.php
+++ b/library/Zend/Controller/Action/Helper/FlashMessenger.php
@@ -150,7 +150,7 @@ class Zend_Controller_Action_Helper_FlashMessenger extends Zend_Controller_Actio
             self::$_session->setExpirationHops(1, null, true);
         }
 
-        if (!is_array(self::$_session->{$this->_namespace})) {
+        if (!is_array(self::$_session->{$namespace})) {
             self::$_session->{$namespace} = array();
         }
 

--- a/tests/Zend/Controller/Action/Helper/FlashMessengerTest.php
+++ b/tests/Zend/Controller/Action/Helper/FlashMessengerTest.php
@@ -154,9 +154,12 @@ class Zend_Controller_Action_Helper_FlashMessengerTest extends PHPUnit_Framework
     {
         $this->helper->addMessage('testmessage', 'foobar');
         $this->assertTrue($this->helper->hasCurrentMessages('foobar'));
+
+        $this->helper->addMessage('testmessage2', 'foobar');
+        $this->assertTrue($this->helper->hasCurrentMessages('foobar'));
+
         $foobarMessages = $this->helper->getCurrentMessages('foobar');
-        $this->assertEquals(1, count($foobarMessages));
-        $this->assertEquals('testmessage', array_pop($foobarMessages));
+        $this->assertEquals(array('testmessage', 'testmessage2'), $foobarMessages);
 
         // Ensure it didnt' bleed over into default namespace
         $defaultMessages = $this->helper->getCurrentMessages();


### PR DESCRIPTION
A typo in addMessage() is erasing previous custom messages if there is not messages in the default namespace.
