### PR TITLE
When clearning current messages from a namespace, it should pass to see ...

### DIFF
--- a/library/Zend/Controller/Action/Helper/FlashMessenger.php
+++ b/library/Zend/Controller/Action/Helper/FlashMessenger.php
@@ -256,7 +256,7 @@ class Zend_Controller_Action_Helper_FlashMessenger extends Zend_Controller_Actio
             $namespace = $this->getNamespace();
         }
         
-        if ($this->hasCurrentMessages()) {
+        if ($this->hasCurrentMessages($namespace)) {
             unset(self::$_session->{$namespace});
             return true;
         }


### PR DESCRIPTION
...whether the namespace has current message or not.

I don't have a CLA. Not sure whether this PR is still accepted or not. Else please fix by yourself.
Thanks
Hari KT
