### PR TITLE
Fix Lucene tests - check if the directory exists before trying to clean it up.

### DIFF
--- a/tests/Zend/Search/Lucene/.gitignore
+++ b/tests/Zend/Search/Lucene/.gitignore
@@ -1,0 +1,4 @@
+_index/*
+_index23Sample/*
+_indexSample/*
+Index/_source/_files/

--- a/tests/Zend/Search/Lucene/Storage/DirectoryTest.php
+++ b/tests/Zend/Search/Lucene/Storage/DirectoryTest.php
@@ -39,14 +39,16 @@ class Zend_Search_Lucene_Storage_DirectoryTest extends PHPUnit_Framework_TestCas
     {
         $tempPath = dirname(__FILE__) . '/_tempFiles/_files';
 
-        // remove files from temporary direcytory
-        $dir = opendir($tempPath);
-        while (($file = readdir($dir)) !== false) {
-            if (!is_dir($tempPath . '/' . $file)) {
-                @unlink($tempPath . '/' . $file);
+        if (is_dir($tempPath)) {
+            // remove files from temporary direcytory
+            $dir = opendir($tempPath);
+            while (($file = readdir($dir)) !== false) {
+                if (!is_dir($tempPath . '/' . $file)) {
+                    @unlink($tempPath . '/' . $file);
+                }
             }
+            closedir($dir);
         }
-        closedir($dir);
 
         $directory = new Zend_Search_Lucene_Storage_Directory_Filesystem($tempPath);
 


### PR DESCRIPTION
This fixes the previously failing tests for Zend_Search: https://travis-ci.org/zendframework/zf1/jobs/8413247#L923

https://travis-ci.org/mhujer/zf1/jobs/8414157#L916
Executing Zend/Search/AllTests.php
PHPUnit 3.4.15 by Sebastian Bergmann.
............................................................  60 / 158
............................................................ 120 / 158
......................................
