### PR TITLE
Fixed Zend_Validate_Db_* tests

### DIFF
--- a/tests/Zend/Validate/Db/NoRecordExistsTest.php
+++ b/tests/Zend/Validate/Db/NoRecordExistsTest.php
@@ -191,8 +191,8 @@ class Zend_Validate_Db_NoRecordExistsTest extends PHPUnit_Framework_TestCase
     {
         Zend_Db_Table_Abstract::setDefaultAdapter($this->_adapterHasResult);
         $validator = new Zend_Validate_Db_NoRecordExists(array('table' => 'users',
-                                                               'schema' => 'my'),
-                                                         'field1');
+                                                               'schema' => 'my',
+                                                               'field' => 'field1'));
         $this->assertFalse($validator->isValid('value1'));
     }
 
@@ -205,8 +205,8 @@ class Zend_Validate_Db_NoRecordExistsTest extends PHPUnit_Framework_TestCase
     {
         Zend_Db_Table_Abstract::setDefaultAdapter($this->_adapterNoResult);
         $validator = new Zend_Validate_Db_NoRecordExists(array('table' => 'users',
-                                                               'schema' => 'my'),
-                                                         'field1');
+                                                               'schema' => 'my',
+                                                               'field' => 'field1'));
         $this->assertTrue($validator->isValid('value1'));
     }
 

--- a/tests/Zend/Validate/Db/RecordExistsTest.php
+++ b/tests/Zend/Validate/Db/RecordExistsTest.php
@@ -190,8 +190,8 @@ class Zend_Validate_Db_RecordExistsTest extends PHPUnit_Framework_TestCase
     {
         Zend_Db_Table_Abstract::setDefaultAdapter($this->_adapterHasResult);
         $validator = new Zend_Validate_Db_RecordExists(array('table' => 'users',
-                                                               'schema' => 'my'),
-                                                         'field1');
+                                                             'schema' => 'my',
+                                                             'field' => 'field1'));
         $this->assertTrue($validator->isValid('value1'));
     }
 
@@ -204,8 +204,8 @@ class Zend_Validate_Db_RecordExistsTest extends PHPUnit_Framework_TestCase
     {
         Zend_Db_Table_Abstract::setDefaultAdapter($this->_adapterNoResult);
         $validator = new Zend_Validate_Db_RecordExists(array('table' => 'users',
-                                                               'schema' => 'my'),
-                                                         'field1');
+                                                             'schema' => 'my',
+                                                             'field' => 'field1'));
         $this->assertFalse($validator->isValid('value1'));
     }
 


### PR DESCRIPTION
`Zend_Validate_Db_*` tests pass proper arguments to constructors.

It is possible to pass either `$options` array or more parameters. Not both.
