### PR TITLE
Fixes #146 - Unit test failed: Zend_Mail_MailTest::testOnlyText

### DIFF
--- a/tests/Zend/Mail/MailTest.php
+++ b/tests/Zend/Mail/MailTest.php
@@ -162,7 +162,7 @@ class Zend_Mail_MailTest extends PHPUnit_Framework_TestCase
         $this->assertContains('From: test Mail User <testmail@example.com>', $mock->header);
         $this->assertContains('Subject: My Subject', $mock->header);
         $this->assertContains('To: recipient1@example.com', $mock->header);
-        $this->assertContains('Cc: Example no. 1 for cc <recipient1_cc@example.com>', $mock->header);
+        $this->assertContains('Cc: "Example no. 1 for cc" <recipient1_cc@example.com>', $mock->header);
     }
 
     /**


### PR DESCRIPTION
Related to #146 
