### PR TITLE
Zend_Service_Twitter_TwitterTest float failure

### DIFF
--- a/tests/Zend/Service/Twitter/TwitterTest.php
+++ b/tests/Zend/Service/Twitter/TwitterTest.php
@@ -394,7 +394,7 @@ class Zend_Service_Twitter_TwitterTest extends PHPUnit_Framework_TestCase
         $twitter->setHttpClient($this->stubTwitter(
             'statuses/show/307529814640840705.json', Zend_Http_Client::GET, 'statuses.show.json'
         ));
-        $response = $twitter->statuses->show(307529814640840705);
+        $response = $twitter->statuses->show('307529814640840705');
         $this->assertTrue($response instanceof Zend_Service_Twitter_Response);
     }
 


### PR DESCRIPTION
Fixes failure when the big int is converted to float.

```
1) Zend_Service_Twitter_TwitterTest::testShowStatusReturnsResponse
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-https://api.twitter.com/1.1/statuses/show/307529814640840705.json
+https://api.twitter.com/1.1/statuses/show/3.0752981464084E+17.json
```
