### PR TITLE
New keyword was missing in Sqs Cloud/QueueService adapter when exception is thrown. Would cause fatal error.

### DIFF
--- a/library/Zend/Cloud/QueueService/Adapter/Sqs.php
+++ b/library/Zend/Cloud/QueueService/Adapter/Sqs.php
@@ -118,7 +118,7 @@ class Zend_Cloud_QueueService_Adapter_Sqs
         try {
             return $this->_sqs->delete($queueId);
         } catch(Zend_Service_Amazon_Exception $e) {
-            throw Zend_Cloud_QueueService_Exception('Error on queue deletion: '.$e->getMessage(), $e->getCode(), $e);
+            throw new Zend_Cloud_QueueService_Exception('Error on queue deletion: '.$e->getMessage(), $e->getCode(), $e);
         }
     }
 


### PR DESCRIPTION
New keyword was missing in Sqs Cloud/QueueService adapter when exception is thrown. Would cause fatal error.
