### PR TITLE
When Method reflection is returning no lines its creating error "undefined variable $firstLine"

### DIFF
--- a/library/Zend/Reflection/Method.php
+++ b/library/Zend/Reflection/Method.php
@@ -152,7 +152,7 @@ class Zend_Reflection_Method extends ReflectionMethod
 
         // Strip off lines until we come to a closing bracket
         do {
-            if (count($lines) == 0) break;
+            if (count($lines) == 0) return "";
             $firstLine = array_shift($lines);
         } while (strpos($firstLine, ')') === false);
 


### PR DESCRIPTION
...the code leads to error "undefined variable  $firstLine".
