### PR TITLE
Fix ZF-11921: Race condition in plugin loader include file cache

### DIFF
--- a/library/Zend/Loader/PluginLoader.php
+++ b/library/Zend/Loader/PluginLoader.php
@@ -490,7 +490,7 @@ class Zend_Loader_PluginLoader implements Zend_Loader_PluginLoader_Interface
      */
     protected static function _appendIncFile($incFile)
     {
-        if (null === self::$_includeFileCacheHandler) {
+        if (!isset(self::$_includeFileCacheHandler)) {
             self::$_includeFileCacheHandler = fopen(self::$_includeFileCache, 'ab');
 
             if (!flock(self::$_includeFileCacheHandler, LOCK_EX | LOCK_NB, $wouldBlock) || $wouldBlock) {


### PR DESCRIPTION
This fixes the race condition described at:
http://framework.zend.com/issues/browse/ZF-11921

For the race to disappear each and every line is made completely independent from the others. This is the reason why every line includes its own php open and close tag, and no file_get_content() is made, and the file is opened in append only mode.

To prevent the insertion of duplicates lines, a fast non blocking lock is made and kept until the end of the request, thus the static $h.

Tested on a highly concurrent server without a problem.
