### PR TITLE
FlashMessenger Action Helper method clearCurrentMessages() not passing namespace to hasCurrentMessages()

### DIFF
--- a/library/Zend/Controller/Action/Helper/FlashMessenger.php
+++ b/library/Zend/Controller/Action/Helper/FlashMessenger.php
@@ -256,7 +256,7 @@ class Zend_Controller_Action_Helper_FlashMessenger extends Zend_Controller_Actio
             $namespace = $this->getNamespace();
         }
         
-        if ($this->hasCurrentMessages()) {
+        if ($this->hasCurrentMessages($namespace)) {
             unset(self::$_session->{$namespace});
             return true;
         }


### PR DESCRIPTION
Affected version: 1.12.3

In the file Zend/Controller/Action/Helper/FlashMessenger.php on line 259. You forgot to pass the $namespace parameter to the method hasCurrentMessages().
