### PR TITLE
Adding form elements with same index causes only the last to be rendered

### DIFF
--- a/library/Zend/Form.php
+++ b/library/Zend/Form.php
@@ -3357,6 +3357,13 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
                     } else {
                         $items[$order] = $key;
                     }
+                } elseif (isset($items[$order]) && $items[$order] !== $key) {
+                    throw new \Zend_Form_Exception('Form elements ' .
+                        $items[$order] . ' and ' . $key .
+                        ' have the same order (' .
+                        $order . ') - ' .
+                        'this would result in only the last added element to be rendered'
+                    );
                 } else {
                     $items[$order] = $key;
                 }


### PR DESCRIPTION
Just spent a good part of yesterday hunting for the root cause of Zend Form not rendering some of my form elements.

Without this patch, the sorting routine overwrites elements if they already exist with the same "order" value, causing them to not be rendered even though they are part of the form for all other purposes. I'm pretty sure this confusing behavior can't be the intention of the framework user, so throwing an exception seems appropriate. Unless someone wishes to create a non-ambiguous solution that automagically handles this?
