### PR TITLE
Disconnected table will create connected row objects when iterated over

### DIFF
--- a/library/Zend/Db/Table/Rowset/Abstract.php
+++ b/library/Zend/Db/Table/Rowset/Abstract.php
@@ -205,6 +205,7 @@ abstract class Zend_Db_Table_Rowset_Abstract implements SeekableIterator, Counta
                 $this->_connected = true;
             }
         }
+        $this->rewind();
         return $this->_connected;
     }
 
@@ -426,6 +427,9 @@ abstract class Zend_Db_Table_Rowset_Abstract implements SeekableIterator, Counta
                     'readOnly' => $this->_readOnly
                 )
             );
+            if ( $this->_rows[$position] instanceof Zend_Db_Table_Row_Abstract ) {
+                $this->_rows[$position]->setTable($this->getTable());
+            }
         }
 
         // return the row object

--- a/tests/Zend/Db/Table/Rowset/TestCommon.php
+++ b/tests/Zend/Db/Table/Rowset/TestCommon.php
@@ -339,4 +339,39 @@ abstract class Zend_Db_Table_Rowset_TestCommon extends Zend_Db_Table_TestSetup
         $rowset->getRow(4);
     }
 
+    /**
+     * @group GH-172
+     */
+    public function testTableRowsetContainsDisconnectedRowObjectsWhenDeserialized()
+    {
+        $table = $this->_table['bugs'];
+        $ser = serialize($table->fetchAll('bug_id = 1', 'bug_id ASC'));
+
+        $rowset = unserialize($ser);
+
+        $row = $rowset->current();
+        $this->assertType('Zend_Db_Table_Row_Abstract', $row); 
+        $this->assertFalse($row->isConnected());
+        $this->assertNull($row->getTable());
+    }
+
+    /**
+     * @group GH-172
+     */
+    public function testConnectedRowObjectsAreCreatedByRowsetAfterSetTableIsCalled()
+    {
+        $table = $this->_table['bugs'];
+        $ser = serialize($table->fetchAll('bug_id = 1', 'bug_id ASC'));
+        $rowset = unserialize($ser);
+
+        // Reconnect the rowset
+        $rowset->setTable($table);
+
+        $this->assertTrue($rowset->isConnected());
+        $row = $rowset->current();
+        $this->assertType('Zend_Db_Table_Row_Abstract', $row);
+        $this->assertTrue($row->isConnected());
+        $this->assertSame($row->getTable(), $table);
+    }
+
 }


### PR DESCRIPTION
Fixes #172 by calling `setTable` on each row object after it's instantiated by the Rowset.
After applying this patch the Zend_Db test suite ran with no additional failures.
