### PR TITLE
Fix exception message check in Zend_Db_Table_TestCommon::testTableExceptionNoPrimaryKey

### DIFF
--- a/tests/Zend/Db/Table/TestCommon.php
+++ b/tests/Zend/Db/Table/TestCommon.php
@@ -498,7 +498,7 @@ abstract class Zend_Db_Table_TestCommon extends Zend_Db_Table_TestSetup
         } catch (Zend_Exception $e) {
             $this->assertType('Zend_Db_Table_Exception', $e,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
-            $this->assertEquals('A table must have a primary key, but none was found', $e->getMessage());
+            $this->assertEquals("A table must have a primary key, but none was found for table '{$tableName}'", $e->getMessage());
         }
 
         $this->_util->dropTable($tableName);


### PR DESCRIPTION
Fix exception message check in Zend_Db_Table_TestCommon::testTableExceptionNoPrimaryKey, which checks output of [this exception throw](https://github.com/zendframework/zf1/blob/master/library/Zend/Db/Table/Abstract.php#L889)

```
1) Zend_Db_Table_Pdo_MysqlTest::testTableExceptionNoPrimaryKey
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-A table must have a primary key, but none was found
+A table must have a primary key, but none was found for table 'zfnoprimarykey'
```
