### PR TITLE
Workaround for ZF1 autoloader + Composer

### DIFF
--- a/library/Zend/Application.php
+++ b/library/Zend/Application.php
@@ -77,7 +77,9 @@ class Zend_Application
     {
         $this->_environment = (string) $environment;
 
-        require_once 'Zend/Loader/Autoloader.php';
+        if (!class_exists('Zend_Loader_Autoloader', true)) {
+            require_once 'Zend/Loader/Autoloader.php';
+        }
         $this->_autoloader = Zend_Loader_Autoloader::getInstance();
 
         if (null !== $options) {


### PR DESCRIPTION
Require_once will cause error if composer-installed ZF1 is not on include path. Either file will be missing or wrong autoloader will be loaded (with possible "cannot redeclare class" error). 
