### PR TITLE
Fixing #157 - preg_replace() with /e modifier under PHP 5.5 is deprecate...

### DIFF
--- a/library/Zend/Ldap/Converter.php
+++ b/library/Zend/Ldap/Converter.php
@@ -69,8 +69,20 @@ class Zend_Ldap_Converter
      */
     public static function hex32ToAsc($string)
     {
-        $string = preg_replace("/\\\([0-9A-Fa-f]{2})/e", "''.chr(hexdec('\\1')).''", $string);
+        // Using a callback, since PHP 5.5 has deprecated the /e modifier in preg_replace.
+        $string = preg_replace_callback("/\\\([0-9A-Fa-f]{2})/", array('Zend_Ldap_Converter', '_charHex32ToAsc'), $string);
         return $string;
+    }
+
+    /**
+     * Convert a single slash-prefixed character from Hex32 to ASCII.
+     * Used as a callback in @see hex32ToAsc()
+     * @param array $matches
+     *
+     * @return string
+     */
+    private static function _charHex32ToAsc(array $matches) {
+        return chr(hexdec($matches[0]));
     }
 
     /**


### PR DESCRIPTION
Replaced preg_replace() with /e modifier with a callback to do the same thing. Unit test passes on PHP 5.4 - depending on Travis to see if it passes for other versions.
