### PR TITLE
Fixed wrong translation for Zend_Filter_Alpha

### DIFF
--- a/documentation/manual/de/module_specs/Zend_Filter-Alpha.xml
+++ b/documentation/manual/de/module_specs/Zend_Filter-Alpha.xml
@@ -7,7 +7,7 @@
     <para>
         <classname>Zend_Filter_Alpha</classname> ist ein Filter der den String
         <varname>$value</varname> zurückgibt, wobei er alle Zeichen entfernt die keine
-        alphanummerischen Zeichen sind. Dieser Filter enthält eine Option welche Leerzeichen
+        alphabetischen Zeichen sind. Dieser Filter enthält eine Option welche Leerzeichen
         erlaubt.
     </para>
 


### PR DESCRIPTION
The translation for Zend_Filter_Alpha said it filters alphanumerical ("alphanummerischen") characters which is wrong. Corrected to alphabetical ("alphabetischen") characters which describes the actual behavior of Zend_Filter_Alpha.
