### PR TITLE
filesize change

### DIFF
--- a/library/Zend/Form/Decorator/Fieldset.php
+++ b/library/Zend/Form/Decorator/Fieldset.php
@@ -26,6 +26,7 @@ require_once 'Zend/Form/Decorator/Abstract.php';
  * Zend_Form_Decorator_Fieldset
  *
  * Any options passed will be used as HTML attributes of the fieldset tag.
+ * 
  *
  * @category   Zend
  * @package    Zend_Form


### PR DESCRIPTION
Increased the file size ever so slightly to get around bug:
https://bugs.php.net/bug.php?id=60758 / https://bugs.php.net/bug.php?id=48034

I believe this bug has been patched in later versions of PHP. However in 5.3.9 or below, loading a file of size 4096 bytes exactly causes apache to crash. I'll never get the infuriating hours I spent debugging this back, but we can save the others! 

It would be really nice if we could just add/remove a byte from this file.
