### PR TITLE
Added JSON_UNESCAPED_UNICODE and JSON_UNESCAPED_SLASHES to encoding APNS Data to JSON

### DIFF
--- a/library/Zend/Mobile/Push/Apns.php
+++ b/library/Zend/Mobile/Push/Apns.php
@@ -310,7 +310,7 @@ class Zend_Mobile_Push_Apns extends Zend_Mobile_Push_Abstract
         foreach($message->getCustomData() as $k => $v) {
             $payload[$k] = $v;
         }
-        $payload = json_encode($payload);
+        $payload = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
         $expire = $message->getExpire();
         if ($expire > 0) {


### PR DESCRIPTION
As APNS documentation says "The payload must not exceed 256 bytes and must not be null-terminated" so inefficiently to use escaped unicode characters and slashes:

``` php
php > echo json_encode("{'key1':'Привет,/ГитХаб/'}");
# "{'key1':'\u041f\u0440\u0438\u0432\u0435\u0442,\/\u0413\u0438\u0442\u0425\u0430\u0431\/'}"
# Lenght: 90
```

``` php
php > echo json_encode("{'key1':'Привет,/ГитХаб/'}", JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
# "{'key1':'Привет,/ГитХаб/'}"
# Lenght: 40
```
