### PR TITLE
Empty action form attribute should not be rendered in HTML5

### DIFF
--- a/library/Zend/View/Helper/Form.php
+++ b/library/Zend/View/Helper/Form.php
@@ -62,6 +62,10 @@ class Zend_View_Helper_Form extends Zend_View_Helper_FormElement
             $name = '';
         }
         
+        if ($this->_isHtml5() && array_key_exists('action', $attribs) && !$attribs['action']) {
+            unset($attribs['action']);
+        }
+
         if ( array_key_exists('name', $attribs) && empty($attribs['id'])) {
             unset($attribs['id']);
         }

--- a/library/Zend/View/Helper/HtmlElement.php
+++ b/library/Zend/View/Helper/HtmlElement.php
@@ -76,6 +76,17 @@ abstract class Zend_View_Helper_HtmlElement extends Zend_View_Helper_Abstract
     }
 
     /**
+     * Is doctype HTML5?
+     *
+     * @return boolean
+     */
+    protected function _isHtml5()
+    {
+        $doctype = $this->view->doctype();
+        return $doctype->isHtml5();
+    }
+
+    /**
      * Is doctype strict?
      *
      * @return boolean

--- a/tests/Zend/View/Helper/FormTest.php
+++ b/tests/Zend/View/Helper/FormTest.php
@@ -167,6 +167,17 @@ class Zend_View_Helper_FormTest extends PHPUnit_Framework_TestCase
         $form = $this->helper->form('FormName', array('action' => '/foo', 'method' => 'get'));
         $this->assertNotRegexp('/<form[^>]*(name="FormName")/', $form);
     }    
+
+    public function testEmptyActionShouldNotRenderActionAttributeInHTML5()
+    {
+        $this->view->doctype(Zend_View_Helper_Doctype::HTML5);
+        $form = $this->helper->form('', array('action' => ''));
+        $this->assertNotRegexp('/<form[^>]*(action="")/', $form);
+        $form = $this->helper->form('', array('action' => null));
+        $this->assertNotRegexp('/<form[^>]*(action="")/', $form);
+        $form = $this->helper->form('');
+        $this->assertNotRegexp('/<form[^>]*(action="")/', $form);
+    }
 }
 
 // Call Zend_View_Helper_FormTest::main() if this source file is executed directly.


### PR DESCRIPTION
"The action and formaction content attributes, if specified, must have a value that is a valid non-empty URL"
(http://www.w3.org/html/wg/drafts/html/master/forms.html#attr-fs-action)
