### PR TITLE
Make tests compatible with PHP 5.3+ magic mime file format

### DIFF
--- a/tests/Zend/Validate/File/IsCompressedTest.php
+++ b/tests/Zend/Validate/File/IsCompressedTest.php
@@ -199,7 +199,12 @@ class Zend_Validate_File_IsCompressedTest extends PHPUnit_Framework_TestCase
             $this->markTestSkipped('This PHP Version has no finfo installed');
         }
 
-        $magicFile = dirname(__FILE__) . '/_files/magic.mime';
+        if (version_compare(PHP_VERSION, '5.3', '>=')) {
+            $magicFile = dirname(__FILE__) . '/_files/magic-php53.mime';
+        } else {
+            $magicFile = dirname(__FILE__) . '/_files/magic.mime';
+        }
+
         $validator = new Zend_Validate_File_IsCompressed(array(
             'image/gif',
             'image/jpg',

--- a/tests/Zend/Validate/File/IsImageTest.php
+++ b/tests/Zend/Validate/File/IsImageTest.php
@@ -178,13 +178,19 @@ class Zend_Validate_File_IsImageTest extends PHPUnit_Framework_TestCase
             $this->markTestSkipped('This PHP Version has no finfo installed');
         }
 
+        if (version_compare(PHP_VERSION, '5.3', '>=')) {
+            $magicFile = dirname(__FILE__) . '/_files/magic-php53.mime';
+        } else {
+            $magicFile = dirname(__FILE__) . '/_files/magic.mime';
+        }
+
         $validator = new Zend_Validate_File_IsImage(array(
             'image/gif',
             'image/jpg',
-            'magicfile' => dirname(__FILE__) . '/_files/magic.mime',
+            'magicfile' => $magicFile,
             'headerCheck' => true));
 
-        $this->assertEquals(dirname(__FILE__) . '/_files/magic.mime', $validator->getMagicFile());
+        $this->assertEquals($magicFile, $validator->getMagicFile());
         $this->assertTrue($validator->getHeaderCheck());
         $this->assertEquals('image/gif,image/jpg', $validator->getMimeType());
     }

--- a/tests/Zend/Validate/File/_files/magic-php53.mime
+++ b/tests/Zend/Validate/File/_files/magic-php53.mime
@@ -1,0 +1,14 @@
+# Magic file
+
+#JPEG
+0	beshort		0xffd8		image/jpeg
+
+## GIF
+0	string		GIF		image/gif
+
+# TIFF
+#					TIFF file, big-endian
+0	string		MM		image/tiff
+#					TIFF file, little-endian
+0	string		II		image/tiff
+


### PR DESCRIPTION
Required magic mime file format has changed in PHP 5.3. This change includes magic file in the new format and use it in tests on PHP 5.3+.
