### PR TITLE
Improve binary key recognition

### DIFF
--- a/library/Zend/Filter/Encrypt/Openssl.php
+++ b/library/Zend/Filter/Encrypt/Openssl.php
@@ -128,7 +128,7 @@ class Zend_Filter_Encrypt_Openssl implements Zend_Filter_Encrypt_Interface
         }
 
         foreach ($keys as $type => $key) {
-            if (is_file(realpath($key)) and is_readable($key)) {
+            if (ctype_print($key) && is_file(realpath($key)) && is_readable($key)) {
                 $file = fopen($key, 'r');
                 $cert = fread($file, 8192);
                 fclose($file);


### PR DESCRIPTION
For certain random binary keys realpath() throws warning:
realpath() expects parameter 1 to be a valid path, string given

With this PR if binary key was given, the file path is not checked at all.
