### PR TITLE
Skip tests for ZF-11344 because the feature is not available in PHP 5.4+

### DIFF
--- a/tests/Zend/Filter/HtmlEntitiesTest.php
+++ b/tests/Zend/Filter/HtmlEntitiesTest.php
@@ -214,9 +214,13 @@ class Zend_Filter_HtmlEntitiesTest extends PHPUnit_Framework_TestCase
      */
     public function testCorrectsForEncodingMismatch()
     {
+        if (version_compare(phpversion(), '5.4', '>=')) {
+            $this->markTestIncomplete('Tested feature ZF-11344 is not available because of PHP bug #63450');
+        }
+
         $string = file_get_contents(dirname(__FILE__) . '/_files/latin-1-text.txt');
 
-        // restore_error_handler can emit an E_WARNING; let's ignore that, as 
+        // restore_error_handler can emit an E_WARNING; let's ignore that, as
         // we want to test the returned value
         set_error_handler(array($this, 'errorHandler'), E_NOTICE | E_WARNING);
         $result = $this->_filter->filter($string);
@@ -230,9 +234,13 @@ class Zend_Filter_HtmlEntitiesTest extends PHPUnit_Framework_TestCase
      */
     public function testStripsUnknownCharactersWhenEncodingMismatchDetected()
     {
+        if (version_compare(phpversion(), '5.4', '>=')) {
+            $this->markTestIncomplete('Tested feature ZF-11344 is not available because of PHP bug #63450');
+        }
+
         $string = file_get_contents(dirname(__FILE__) . '/_files/latin-1-text.txt');
 
-        // restore_error_handler can emit an E_WARNING; let's ignore that, as 
+        // restore_error_handler can emit an E_WARNING; let's ignore that, as
         // we want to test the returned value
         set_error_handler(array($this, 'errorHandler'), E_NOTICE | E_WARNING);
         $result = $this->_filter->filter($string);
@@ -248,7 +256,7 @@ class Zend_Filter_HtmlEntitiesTest extends PHPUnit_Framework_TestCase
     {
         $string = file_get_contents(dirname(__FILE__) . '/_files/latin-1-dash-only.txt');
 
-        // restore_error_handler can emit an E_WARNING; let's ignore that, as 
+        // restore_error_handler can emit an E_WARNING; let's ignore that, as
         // we want to test the returned value
         // Also, explicit try, so that we don't mess up PHPUnit error handlers
         set_error_handler(array($this, 'errorHandler'), E_NOTICE | E_WARNING);


### PR DESCRIPTION
There is a bug in PHP - [#63450](https://bugs.php.net/bug.php?id=48147) related to [bug in glibc](http://sourceware.org/bugzilla/show_bug.cgi?id=13541).

These make the feature [ZF-11344](http://framework.zend.com/issues/browse/ZF-11344) not available since PHP 5.4. This is not a big problem, because the faulty state is handled properly in the filter - it throws an exception if the `iconv()` or `htmlentities()` returns empty string or false.

Similar test skip is also in zf2:
https://github.com/zendframework/zf2/pull/1162/files
