### PR TITLE
link to travis should be without www subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the Zend Framework 1.12 Release! 
 
-Master: [![Build Status](https://api.travis-ci.org/zendframework/zf1.png?branch=master)](https://www.travis-ci.org/zendframework/zf1)
+Master: [![Build Status](https://api.travis-ci.org/zendframework/zf1.png?branch=master)](https://travis-ci.org/zendframework/zf1)
 
 RELEASE INFORMATION
 ===================


### PR DESCRIPTION
currently, https://www.travis-ci.org/zendframework/zf1 could not be access.
