### PR TITLE
Added normalize bypass for ZendServer_ShMem

### DIFF
--- a/library/Zend/Cache.php
+++ b/library/Zend/Cache.php
@@ -217,7 +217,7 @@ abstract class Zend_Cache
      */
     protected static function _normalizeName($name)
     {
-        if( strtolower($name) == 'zendserver_shmem' ){
+        if (strtolower($name) == 'zendserver_shmem') {
             return 'ZendServer_ShMem';
         }
         


### PR DESCRIPTION
I got an error when using ShMem as backend, because the ShMem becomes "Shmem", which results in errors in a later stage.
