### PR TITLE
Zend_Oauth_Client: Consider multipart/form-data

### DIFF
--- a/library/Zend/Oauth/Client.php
+++ b/library/Zend/Oauth/Client.php
@@ -292,27 +292,20 @@ class Zend_Oauth_Client extends Zend_Http_Client
 
     /**
      * Collect all signable parameters into a single array across query string
-     * and POST body. These are returned as a properly formatted single
-     * query string.
+     * and POST body. Don't include POST parameters if content type is multipart POST.
      *
-     * @return string
+     * @return array
      */
     protected function _getSignableParametersAsQueryString()
     {
         $params = array();
-            if (!empty($this->paramsGet)) {
-                $params = array_merge($params, $this->paramsGet);
-                $query  = $this->getToken()->toQueryString(
-                    $this->getUri(true), $this->_config, $params
-                );
-            }
-            if (!empty($this->paramsPost)) {
-                $params = array_merge($params, $this->paramsPost);
-                $query  = $this->getToken()->toQueryString(
-                    $this->getUri(true), $this->_config, $params
-                );
-            }
-            return $params;
+        if (!empty($this->paramsGet)) {
+            $params = array_merge($params, $this->paramsGet);
+        }
+        if ($this->enctype != self::ENC_FORMDATA && !empty($this->paramsPost)) {
+            $params = array_merge($params, $this->paramsPost);
+        }
+        return $params;
     }
 
     /**

--- a/tests/Zend/Oauth/ClientTest.php
+++ b/tests/Zend/Oauth/ClientTest.php
@@ -22,6 +22,14 @@
 
 require_once 'Zend/Oauth.php';
 require_once 'Zend/Oauth/Config.php';
+require_once 'Zend/Oauth/Client.php';
+
+class Test_Oauth_Client extends Zend_Oauth_Client {
+    public function getSignableParametersAsQueryString()
+    {
+        return $this->_getSignableParametersAsQueryString();
+    }
+}
 
 /**
  * @category   Zend
@@ -45,5 +53,37 @@ class Zend_Oauth_ClientTest extends PHPUnit_Framework_TestCase
     {
         $this->client->setRequestMethod(Zend_Oauth_Client::OPTIONS);
         $this->assertEquals(Zend_Oauth_Client::OPTIONS, $this->client->getRequestMethod());
+    }
+
+    /**
+     * zendframework / zf1 # 244
+     */
+    public function testIncludesParametersForSignatureOnPostEncUrlEncoded()
+    {
+        $client = new Test_Oauth_Client(array());
+        $client->setEncType(Zend_Http_Client::ENC_URLENCODED);
+        $params = array(
+            'param1' => 'dummy1',
+            'param2' => 'dummy2',
+        );
+        $client->setParameterPost($params);
+        $client->setMethod(Zend_Http_Client::POST);
+        $this->assertEquals(2, count($client->getSignableParametersAsQueryString()));
+    }
+
+    /**
+     * zendframework / zf1 # 244
+     */
+    public function testExcludesParametersOnPostEncFormData()
+    {
+        $client = new Test_Oauth_Client(array());
+        $client->setEncType(Zend_Http_Client::ENC_FORMDATA);
+        $params = array(
+            'param1' => 'dummy1',
+            'param2' => 'dummy2',
+        );
+        $client->setParameterPost($params);
+        $client->setMethod(Zend_Http_Client::POST);
+        $this->assertEquals(0, count($client->getSignableParametersAsQueryString()));
     }
 }


### PR DESCRIPTION
Parameters being sent that are not the oauth_\* named parameters do not become part of the OAuth signature base string when the HTTP method being used is POST but the post body is not of the "Content-Type: x-www-form-urlencoded" variety.

Consider multipart/form-data encoding when retrieving parameters to encode:
- Fix indentation in _getSignableParametersAsQueryString method
- Remove comment that states that a query string is returned
- Change return type to array in docblock
- Remove unnecessary code that created the query string which
  is not used.
- Add code to not include POST parameters when encoding is
  multipart/form-data

Problem popped up when I tried to send images to the twitter API. The encoding has to be multipart/form-data and the API didn't validate my credentials because they were simply wrong for that case.
