### PR TITLE
Added PSR-0 entry for ZendX namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     },
     "autoload": {
         "psr-0": {
-            "Zend_": "library/"
+            "Zend_": "library/",
+            "ZendX_": "extras/library/",
         }
     },
     "include-path": [


### PR DESCRIPTION
For people that do not use the extras, this only adds 45 extra entries to the generated autoloading classmap, which compared to the main library is negligible.
