### PR TITLE
Update Exception.php

### DIFF
--- a/library/Zend/Db/Adapter/Exception.php
+++ b/library/Zend/Db/Adapter/Exception.php
@@ -46,7 +46,7 @@ class Zend_Db_Adapter_Exception extends Zend_Db_Exception
 
     public function hasChainedException()
     {
-        return ($this->_previous !== null);
+        return ($this->getPrevious() !== null);
     }
 
     public function getChainedException()


### PR DESCRIPTION
$this->_previous is private and cannot be used in Zend_Db_Adapter_Exception
