### PR TITLE
Drop test tables only if exists, to prevent errors on clean database

### DIFF
--- a/tests/Zend/Test/PHPUnit/Db/Integration/MysqlIntegrationTest.php
+++ b/tests/Zend/Test/PHPUnit/Db/Integration/MysqlIntegrationTest.php
@@ -57,8 +57,8 @@ class Zend_Test_PHPUnit_Db_Integration_MysqlIntegrationTest extends Zend_Test_PH
         );
 
         $this->dbAdapter = Zend_Db::factory('pdo_mysql', $params);
-        $this->dbAdapter->query("DROP TABLE foo");
-        $this->dbAdapter->query("DROP TABLE bar");
+        $this->dbAdapter->query("DROP TABLE IF EXISTS foo");
+        $this->dbAdapter->query("DROP TABLE IF EXISTS bar");
         $this->dbAdapter->query(
             'CREATE TABLE foo (id INT(10) AUTO_INCREMENT PRIMARY KEY, foo VARCHAR(255), bar VARCHAR(255), baz VARCHAR(255)) AUTO_INCREMENT=1'
         );


### PR DESCRIPTION
See #261 & #272 for reference.

On clean database the tables foo and bar do not exists during the first run, so we get errors like:

```
1) Zend_Test_PHPUnit_Db_Integration_MysqlIntegrationTest::testZendDbTableDataSet
Zend_Db_Statement_Exception: SQLSTATE[42S02]: Base table or view not found: 1051 Unknown table 'foo', query was: DROP TABLE foo
```

This PR adds IF EXISTS clause to the drop query, making it work even on new and empty database.
