### PR TITLE
[ci skip] Fixed style in zend date constants page(japanese documentation)

### DIFF
--- a/documentation/manual/ja/module_specs/Zend_Date-Constants.xml
+++ b/documentation/manual/ja/module_specs/Zend_Date-Constants.xml
@@ -479,7 +479,7 @@
                 </thead>
                 <tbody>
                     <row>
-                        <entry><constant>Zend_Date::ISO_860</constant>1</entry>
+                        <entry><constant>Zend_Date::ISO_8601</constant></entry>
                         <entry><acronym>ISO</acronym> 8601 形式の日付 (文字列)</entry>
                         <entry>2009-02-13T14:53:27+01:00</entry>
                         <entry><emphasis>2009-02-13T14:53:27+01:00</emphasis>


### PR DESCRIPTION
Fixed style in [zend date constants page(ja)](http://framework.zend.com/manual/1.12/ja/zend.date.constants.html)

Include `Zend_Date::ISO_8601` in constant tags.
