### PR TITLE
Check that pathinfo() has returned an extension

### DIFF
--- a/library/Zend/Validate/File/Extension.php
+++ b/library/Zend/Validate/File/Extension.php
@@ -196,6 +196,12 @@ class Zend_Validate_File_Extension extends Zend_Validate_Abstract
             $info['extension'] = substr($file['name'], strrpos($file['name'], '.') + 1);
         } else {
             $info = pathinfo($value);
+            if (!array_key_exists('extension', $info)) {
+                // From the manual at http://php.net/pathinfo:
+                // "If the path does not have an extension, no extension element
+                // will be returned (see second example below)."
+                return false;
+            }
         }
 
         $extensions = $this->getExtension();

--- a/tests/Zend/Validate/File/ExtensionTest.php
+++ b/tests/Zend/Validate/File/ExtensionTest.php
@@ -115,6 +115,27 @@ class Zend_Validate_File_ExtensionTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(array_key_exists('fileExtensionFalse', $validator->getMessages()));
     }
 
+    /**
+     * GitHub issue #287
+     *
+     * pathinfo() does not guarantee that the extension index will be set
+     * according to the PHP manual (http://se2.php.net/pathinfo#example-2422).
+     *
+     * @return void
+     */
+    public function testNoExtension()
+    {
+        $files = array(
+            'name'     => 'no_extension',
+            'type'     => 'text',
+            'size'     => 200,
+            'tmp_name' => dirname(__FILE__) . '/_files/no_extension',
+            'error'    => 0
+        );
+        $validator = new Zend_Validate_File_Extension('txt');
+        $this->assertEquals(false, $validator->isValid(dirname(__FILE__) . '/_files/no_extension'));
+    }
+
     public function testZF3891()
     {
         $files = array(

--- a/tests/Zend/Validate/File/_files/no_extension
+++ b/tests/Zend/Validate/File/_files/no_extension
@@ -1,0 +1,1 @@
+This file has no extension.


### PR DESCRIPTION
Prevent the notice that is generated when pathinfo() doesn't return an
'extension' element in Zend_Validate_File_Extension.

Fixes #287
