### PR TITLE
Rely on the autoloader to load PHPUnit_Runner_Version and PHPUnit_Autoload

### DIFF
--- a/library/Zend/Test/PHPUnit/ControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/ControllerTestCase.php
@@ -19,15 +19,6 @@
  * @version    $Id$
  */
 
-/** @see PHPUnit_Runner_Version */
-require_once 'PHPUnit/Runner/Version.php';
-
-/**
- * Depending on version, include the proper PHPUnit support
- * @see PHPUnit_Autoload
- */
-require_once (version_compare(PHPUnit_Runner_Version::id(), '3.5.0', '>=')) ? 'PHPUnit/Autoload.php' : 'PHPUnit/Framework.php';
-
 /** @see Zend_Controller_Front */
 require_once 'Zend/Controller/Front.php';
 


### PR DESCRIPTION
Note that I've removed the test that loads PHPUnit_Framework for PHPUnit before 3.5, PHPUnit_Autoload for PHPUnit 3.5 and later. I assume no one will be using the latest ZF1 with such an old PHPUnit.
