### PR TITLE
Fix bug in Zend_Controller_Plugin_ErrorHandler when use ZF1 with PHPDaemon

### DIFF
--- a/library/Zend/Controller/Plugin/ErrorHandler.php
+++ b/library/Zend/Controller/Plugin/ErrorHandler.php
@@ -192,6 +192,15 @@ class Zend_Controller_Plugin_ErrorHandler extends Zend_Controller_Plugin_Abstrac
     }
 
     /**
+     * Shutdown dispatch hook -- Reinitialize class members
+     */
+    public function dispatchLoopShutdown()
+    {
+        $this->_isInsideErrorHandlerLoop = false;
+        $this->_exceptionCountAtFirstEncounter = 0;
+    }
+
+    /**
      * Route shutdown hook -- Ccheck for router exceptions
      *
      * @param Zend_Controller_Request_Abstract $request


### PR DESCRIPTION
Hi. I use ZF1 with PHPDaemon, my app always in memory. Zend_Controller_Plugin_ErrorHandler::_handleError() does not work after first exception request.
