### PR TITLE
Vagrant provisioning fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ vendor/*
 composer.lock
 bin/dbunit
 bin/phpunit
+.vagrant

--- a/puppet/scripts/php-build.sh
+++ b/puppet/scripts/php-build.sh
@@ -78,10 +78,10 @@ sudo make install
 
 echo "Installing PHPUnit"
 export PATH=/usr/local/php/${VERSION}/bin:/usr/local/bin:/usr/bin:/bin:/vagrant/puppet/scripts
-sudo pear update-channels
-sudo pear upgrade-all
-sudo pear config-set auto_discover 1
-sudo pear install pear.phpunit.de/PHPUnit-3.4.15
+pear update-channels
+pear upgrade-all
+pear config-set auto_discover 1
+pear install pear.phpunit.de/PHPUnit-3.4.15
 
 
 echo ""


### PR DESCRIPTION
Added .vagrant folder to .gitignore because vagranfile is at project root directory and if you want to init your machine you will generate vagrant files.

php-build.sh removed sudo from pear commands, because export is configure for local user, this way the script was not able to find pear command. (Tested and working now, pear is running fine)
