### PR TITLE
Default session.hash_bits_per_character

### DIFF
--- a/library/Zend/Session.php
+++ b/library/Zend/Session.php
@@ -530,7 +530,7 @@ class Zend_Session extends Zend_Session_Abstract
 
         $hashBitsPerChar = ini_get('session.hash_bits_per_character');
         if (!$hashBitsPerChar) {
-            $hashBitsPerChar = 5; // the default value
+            $hashBitsPerChar = 4; // the default value
         }
         switch($hashBitsPerChar) {
             case 4: $pattern = '^[0-9a-f]*$'; break;


### PR DESCRIPTION
Change default session.hash_bits_per_character to 4.
http://www.php.net/manual/en/session.configuration.php
