### PR TITLE
Allow session garbage collection to use an index

### DIFF
--- a/library/Zend/Session/SaveHandler/DbTable.php
+++ b/library/Zend/Session/SaveHandler/DbTable.php
@@ -386,9 +386,8 @@ class Zend_Session_SaveHandler_DbTable
      */
     public function gc($maxlifetime)
     {
-        $this->delete($this->getAdapter()->quoteIdentifier($this->_modifiedColumn, true) . ' + '
-                    . $this->getAdapter()->quoteIdentifier($this->_lifetimeColumn, true) . ' < '
-                    . $this->getAdapter()->quote(time()));
+        $this->delete($this->getAdapter()->quoteIdentifier($this->_modifiedColumn, true) . ' < '
+                    . $this->getAdapter()->quote(time() - $this->_lifetime));
 
         return true;
     }


### PR DESCRIPTION
Performing arithmetic in the where clause prevents MySQL from using an index. The garbage collection becomes increasingly more expensive to run as traffic grows.
