### PR TITLE
added a failing test for Zend_Date::isDate

### DIFF
--- a/tests/Zend/DateTest.php
+++ b/tests/Zend/DateTest.php
@@ -5716,6 +5716,11 @@ class Zend_DateTest extends PHPUnit_Framework_TestCase
             $date->getTimezoneFromString('America/New_York')
         );
     }
+    
+    public function testIsDateShouldReturnFalseForNotMatchingFormat()
+    {
+        $this->assertFalse(Zend_Date::isDate('2009 - some text', 'dd.MM.yyyy'));
+    }
 }
 
 class Zend_Date_TestHelper extends Zend_Date


### PR DESCRIPTION
A value that should be in a given format is only a date if it is in the given format.
