### PR TITLE
Fixed bug - do not allow invalid hostname with double dots i.e. zend..com

### DIFF
--- a/library/Zend/Validate/Hostname.php
+++ b/library/Zend/Validate/Hostname.php
@@ -1148,6 +1148,12 @@ class Zend_Validate_Hostname extends Zend_Validate_Abstract
                     // Check each hostname part
                     $check = 0;
                     foreach ($domainParts as $domainPart) {
+                        // If some domain part is empty (i.e. zend..com), it's invalid
+                        if (empty($domainPart)) {
+                            $this->_error(self::INVALID_HOSTNAME);
+                            return false;
+                        }
+
                         // Decode Punycode domainnames to IDN
                         if (strpos($domainPart, 'xn--') === 0) {
                             $domainPart = $this->decodePunycode(substr($domainPart, 4));

--- a/tests/Zend/Uri/HttpTest.php
+++ b/tests/Zend/Uri/HttpTest.php
@@ -159,6 +159,11 @@ class Zend_Uri_HttpTest extends PHPUnit_Framework_TestCase
         $this->_testInvalidUri('http://andi:pass%word@www.zend.com');
     }
 
+    public function testMissingDomainParts()
+    {
+        $this->_testInvalidUri('https://www.zend..com');
+    }
+
     public function testHostAsIP()
     {
         $this->_testValidUri('http://127.0.0.1');


### PR DESCRIPTION
There is a bug in Zend_Validate_Hostname, accepting invalid hostnames such as zend..com with double dots (empty domain parts). Created a unit test & fix.
