### PR TITLE
Update usage of iconv_get_encoding so that it is only used for PHP < 5.6

### DIFF
--- a/library/Zend/Validate/Hostname.php
+++ b/library/Zend/Validate/Hostname.php
@@ -1105,7 +1105,9 @@ class Zend_Validate_Hostname extends Zend_Validate_Abstract
         if ((count($domainParts) > 1) && (strlen($value) >= 4) && (strlen($value) <= 254)) {
             $status = false;
 
-            $origenc = iconv_get_encoding('internal_encoding');
+            $origenc = PHP_VERSION_ID < 50600
+                        ? iconv_get_encoding('internal_encoding')
+                        : ini_get('default_charset');
             if (PHP_VERSION_ID < 50600) {
                 iconv_set_encoding('internal_encoding', 'UTF-8');
             } else {

--- a/library/Zend/Validate/StringLength.php
+++ b/library/Zend/Validate/StringLength.php
@@ -199,7 +199,9 @@ class Zend_Validate_StringLength extends Zend_Validate_Abstract
     public function setEncoding($encoding = null)
     {
         if ($encoding !== null) {
-            $orig   = iconv_get_encoding('internal_encoding');
+            $orig = PHP_VERSION_ID < 50600
+                        ? iconv_get_encoding('internal_encoding')
+                        : ini_get('default_charset');
             if (PHP_VERSION_ID < 50600) {
                 $result = iconv_set_encoding('internal_encoding', $encoding);
             } else {

--- a/tests/Zend/Mail/MessageTest.php
+++ b/tests/Zend/Mail/MessageTest.php
@@ -81,8 +81,11 @@ class Zend_Mail_MessageTest extends PHPUnit_Framework_TestCase
     {
         $message = new Zend_Mail_Message(array('file' => $this->_file));
 
-        $this->assertEquals($message->from, iconv('UTF-8', iconv_get_encoding('internal_encoding'),
-                                                                   '"Peter Müller" <peter-mueller@example.com>'));
+        $enc = PHP_VERSION_ID < 50600
+            ? iconv_get_encoding('internal_encoding')
+            : ini_get('default_charset');
+
+        $this->assertEquals($message->from, iconv('UTF-8', $enc, '"Peter Müller" <peter-mueller@example.com>'));
     }
 
     public function testGetHeaderAsArray()

--- a/tests/Zend/Validate/HostnameTest.php
+++ b/tests/Zend/Validate/HostnameTest.php
@@ -50,7 +50,9 @@ class Zend_Validate_HostnameTest extends PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->_origEncoding = iconv_get_encoding('internal_encoding');
+        $this->_origEncoding = PHP_VERSION_ID < 50600
+                    ? iconv_get_encoding('internal_encoding')
+                    : ini_get('default_charset');
         $this->_validator = new Zend_Validate_Hostname();
     }
 


### PR DESCRIPTION
Based on the change made here:  https://github.com/zendframework/zf2/blob/master/tests/ZendTest/Validator/HostnameTest.php#L33
