### PR TITLE
Fix for array to string conversion error

### DIFF
--- a/library/Zend/Validate/Abstract.php
+++ b/library/Zend/Validate/Abstract.php
@@ -229,6 +229,8 @@ abstract class Zend_Validate_Abstract implements Zend_Validate_Interface
             } else {
                 $value = $value->__toString();
             }
+        } elseif (is_array($value)) {
+            $value = json_encode($value);
         } else {
             $value = implode((array) $value);
         }


### PR DESCRIPTION
Fix for array to string conversion error when the $value variable has nested levels of arrays.
