### PR TITLE
Add Docx support to Zend_Gdata_Docs

### DIFF
--- a/library/Zend/Gdata/Docs.php
+++ b/library/Zend/Gdata/Docs.php
@@ -67,7 +67,7 @@ class Zend_Gdata_Docs extends Zend_Gdata
 
     protected $_defaultPostUri = self::DOCUMENTS_LIST_FEED_URI;
 
-    private static $SUPPORTED_FILETYPES = array(
+    protected static $SUPPORTED_FILETYPES = array(
       'TXT'=>'text/plain',
       'CSV'=>'text/csv',
       'TSV'=>'text/tab-separated-values',


### PR DESCRIPTION
- adds another file type/extension
- relaxes private variable to allow overriding it by extending the class
