### PR TITLE
Allow children of Zend_Form to handle setDefaults to array conversion by themselves

### DIFF
--- a/library/Zend/Form.php
+++ b/library/Zend/Form.php
@@ -1268,11 +1268,16 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      *
      * Sets values for all elements specified in the array of $defaults.
      *
-     * @param  array $defaults
+     * @param  array|Traversable $defaults
+     * @throws Zend_Form_Exception When invalid type is passed
      * @return Zend_Form
      */
     public function setDefaults($defaults)
     {
+        if (!is_array($defaults) && !$defaults instanceof Traversable) {
+            throw new Zend_Form_Exception('Argument passed to setDefaults() must be of type array or Traversable.');
+        }
+
         $eBelongTo = null;
 
         if ($this->isArray()) {

--- a/tests/Zend/Form/FormTest.php
+++ b/tests/Zend/Form/FormTest.php
@@ -4865,6 +4865,32 @@ class Zend_Form_FormTest extends PHPUnit_Framework_TestCase
         //this would throw a strict warning if the setDefaults() method requires param to be array
         $form = new Zend_Form_FormTest_SetDefaults();
     }
+
+    public function testCanSetElementDefaultValuesFromTraversable()
+    {
+        $this->testCanAddAndRetrieveMultipleElements();
+        $values = array(
+            'foo' => 'foovalue',
+            'bar' => 'barvalue',
+            'baz' => 'bazvalue',
+            'bat' => 'batvalue',
+        );
+        $traversable = new ArrayIterator($values);
+        $this->form->setDefaults($traversable);
+        $elements = $this->form->getElements();
+        foreach (array_keys($values) as $name) {
+            $this->assertEquals($name . 'value', $elements[$name]->getValue());
+        }
+    }
+
+    /**
+     * @expectedException Zend_Form_Exception
+     * @expectedExceptionMessage Argument passed to setDefaults() must be of type array or Traversable.
+     */
+    public function testSetDefaultsWithInvalidTypeThrowsException()
+    {
+        $this->form->setDefaults(new stdClass());
+    }
 }
 
 class Zend_Form_FormTest_SetDefaults extends Zend_Form


### PR DESCRIPTION
I suggest removing of the `array` typehint in the `Zend_Form::setDefaults()` method as it prevents us from overriding it to accept `Zend_Db_Row`, convert it to array and call the `setDefaults` from parent.

```
Declaration of Form::setDefaults() should be compatible with Zend_Form::setDefaults(array $defaults)
```

I can also improve it further and add an automatic handling of passed objects with toArray() method, what do you think?
