### PR TITLE
Unit test for ZF-1.12.7 (issue #378 & #381)

### DIFF
--- a/tests/Zend/Db/Select/Pdo/PgsqlTest.php
+++ b/tests/Zend/Db/Select/Pdo/PgsqlTest.php
@@ -184,7 +184,7 @@ class Zend_Db_Select_Pdo_PgsqlTest extends Zend_Db_Select_TestCommon
      * @group ZF-378
      * @group ZF-381
      */
-    public function testOrderOfConditionalFieldWithDirection($adapter)
+    public function testOrderOfConditionalFieldWithDirection()
     {
         $select = $this->_db->select();
         $select->from(array ('p' => 'product'))

--- a/tests/Zend/Db/Select/Pdo/SqliteTest.php
+++ b/tests/Zend/Db/Select/Pdo/SqliteTest.php
@@ -231,7 +231,7 @@ class Zend_Db_Select_Pdo_SqliteTest extends Zend_Db_Select_TestCommon
      * @group ZF-378
      * @group ZF-381
      */
-    public function testOrderOfConditionalFieldWithDirection($adapter)
+    public function testOrderOfConditionalFieldWithDirection()
     {
         $select = $this->_db->select();
         $select->from(array ('p' => 'product'))

--- a/tests/Zend/Db/Select/StaticTest.php
+++ b/tests/Zend/Db/Select/StaticTest.php
@@ -878,7 +878,7 @@ class Zend_Db_Select_StaticTest extends Zend_Db_Select_TestCommon
      * @group ZF-378
      * @group ZF-381
      */
-    public function testOrderOfConditionalFieldWithDirection($adapter)
+    public function testOrderOfConditionalFieldWithDirection()
     {
         $select = $this->_db->select();
         $select->from(array ('p' => 'product'))

--- a/tests/Zend/Db/Select/TestCommon.php
+++ b/tests/Zend/Db/Select/TestCommon.php
@@ -1814,7 +1814,7 @@ abstract class Zend_Db_Select_TestCommon extends Zend_Db_TestSetup
      * @group ZF-378
      * @group ZF-381
      */
-    public function testOrderOfConditionalFieldWithDirection($adapter)
+    public function testOrderOfConditionalFieldWithDirection()
     {
         $select = $this->_db->select();
         $select->from(array ('p' => 'product'))

--- a/tests/Zend/Db/Table/Select/Pdo/PgsqlTest.php
+++ b/tests/Zend/Db/Table/Select/Pdo/PgsqlTest.php
@@ -188,7 +188,7 @@ class Zend_Db_Table_Select_Pdo_PgsqlTest extends Zend_Db_Table_Select_TestCommon
      * @group ZF-378
      * @group ZF-381
      */
-    public function testOrderOfConditionalFieldWithDirection($adapter)
+    public function testOrderOfConditionalFieldWithDirection()
     {
         $select = $this->_db->select();
         $select->from(array ('p' => 'product'))

--- a/tests/Zend/Db/Table/Select/Pdo/SqliteTest.php
+++ b/tests/Zend/Db/Table/Select/Pdo/SqliteTest.php
@@ -235,7 +235,7 @@ class Zend_Db_Table_Select_Pdo_SqliteTest extends Zend_Db_Table_Select_TestCommo
      * @group ZF-378
      * @group ZF-381
      */
-    public function testOrderOfConditionalFieldWithDirection($adapter)
+    public function testOrderOfConditionalFieldWithDirection()
     {
         $select = $this->_db->select();
         $select->from(array ('p' => 'product'))

--- a/tests/Zend/Db/Table/Select/StaticTest.php
+++ b/tests/Zend/Db/Table/Select/StaticTest.php
@@ -754,7 +754,7 @@ class Zend_Db_Table_Select_StaticTest extends Zend_Db_Select_TestCommon
      * @group ZF-378
      * @group ZF-381
      */
-    public function testOrderOfConditionalFieldWithDirection($adapter)
+    public function testOrderOfConditionalFieldWithDirection()
     {
         $select = $this->_db->select();
         $select->from(array ('p' => 'product'))


### PR DESCRIPTION
Unit test for ZF-1.12.7 (issue #378 & #381) regarding select statements with ordering direction, multiple order fields and conditional ordering.
