### PR TITLE
Serialized DateTime includes fractions of seconds since 5.6.0beta4

### DIFF
--- a/tests/Zend/Ldap/ConverterTest.php
+++ b/tests/Zend/Ldap/ConverterTest.php
@@ -119,6 +119,13 @@ class Zend_Ldap_ConverterTest extends PHPUnit_Framework_TestCase
                 array('O:8:"DateTime":0:{}', new DateTime('@0')),
                 array('a:3:{i:0;s:4:"test";i:1;i:1;s:3:"foo";s:3:"bar";}', array('test',1,'foo'=>'bar')),
             );
+        } elseif (version_compare(PHP_VERSION, '5.6.0beta4', '>=')) {
+            return array(
+                array('N;', null),
+                array('i:1;', 1),
+                array('O:8:"DateTime":3:{s:4:"date";s:26:"1970-01-01 00:00:00.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}', new DateTime('@0')),
+                array('a:3:{i:0;s:4:"test";i:1;i:1;s:3:"foo";s:3:"bar";}', array('test',1,'foo'=>'bar')),
+            );
         } else {
             return array(
                 array('N;', null),


### PR DESCRIPTION
https://github.com/php/php-src/blob/php-5.6.0beta4/NEWS

> Date: Fixed bug #67308 (Serialize of DateTime truncates fractions of second). (Adam)

```
1) Zend_Ldap_ConverterTest::testToLdapSerialize with data set #2 ('O:8:"DateTime":3:{s:4:"date";s:19:"1970-01-01 00:00:00";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}', DateTime)
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'O:8:"DateTime":3:{s:4:"date";s:19:"1970-01-01 00:00:00";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}'
+'O:8:"DateTime":3:{s:4:"date";s:26:"1970-01-01 00:00:00.000000";s:13:"timezone_type";i:1;s:8:"timezone";s:6:"+00:00";}'
```
