### PR TITLE
Add missing return to _getEncoding()

### DIFF
--- a/library/Zend/Locale/Format.php
+++ b/library/Zend/Locale/Format.php
@@ -1288,6 +1288,7 @@ class Zend_Locale_Format
             ? iconv_get_encoding('internal_encoding')
             : ini_get('default_charset');
 
+        return $oenc;
     }
 
     /**


### PR DESCRIPTION
Fix bug in Zend_Locale_Format::_getEncoding()
