### PR TITLE
Zend_Service_Flickr : Bugfix: Changed endpoint from HTTP to HTTPS

### DIFF
--- a/library/Zend/Service/Flickr.php
+++ b/library/Zend/Service/Flickr.php
@@ -36,7 +36,7 @@ class Zend_Service_Flickr
     /**
      * Base URI for the REST client
      */
-    const URI_BASE = 'http://www.flickr.com';
+    const URI_BASE = 'https://www.flickr.com';
 
     /**
      * Your Flickr API key


### PR DESCRIPTION
HTTP isn't supported anymore by Flickr so HTTPS has to be used instead.
