### PR TITLE
Validate_Hostname: Punycode decoding fails if encoded string has not hyphen

### DIFF
--- a/library/Zend/Validate/Hostname.php
+++ b/library/Zend/Validate/Hostname.php
@@ -1264,22 +1264,19 @@ class Zend_Validate_Hostname extends Zend_Validate_Abstract
      */
     protected function decodePunycode($encoded)
     {
-        $found = preg_match('/([^a-z0-9\x2d]{1,10})$/i', $encoded);
-        if (empty($encoded) || ($found > 0)) {
-            // no punycode encoded string, return as is
+        if (!preg_match('/^[a-z0-9-]+$/i', $encoded)) {
+            // no punycode encoded string
             $this->_error(self::CANNOT_DECODE_PUNYCODE);
             return false;
         }
 
+        $decoded = array();
         $separator = strrpos($encoded, '-');
         if ($separator > 0) {
             for ($x = 0; $x < $separator; ++$x) {
                 // prepare decoding matrix
                 $decoded[] = ord($encoded[$x]);
             }
-        } else {
-            $this->_error(self::CANNOT_DECODE_PUNYCODE);
-            return false;
         }
 
         $lengthd = count($decoded);

--- a/tests/Zend/Validate/HostnameTest.php
+++ b/tests/Zend/Validate/HostnameTest.php
@@ -334,7 +334,7 @@ class Zend_Validate_HostnameTest extends PHPUnit_Framework_TestCase
 
         // Check TLD matching
         $valuesExpected = array(
-            array(true, array('xn--brger-kva.com')),
+            array(true, array('xn--brger-kva.com', 'xn--eckwd4c7cu47r2wf.jp')),
             array(false, array('xn--brger-x45d2va.com', 'xn--bürger.com', 'xn--'))
             );
         foreach ($valuesExpected as $element) {


### PR DESCRIPTION
This is a backported pull request. ZF2's PR is: https://github.com/zendframework/zf2/pull/4636

> When validating host name like "xn--eckwd4c7cu47r2wf.jp", punycode decoder fails.
> 
> In typically case of Japanese(Maybe also Chinese and Korean) domain name, it hasn't ASCII characters. Then, encoded string has not hyphen after "xn--". In this case, current code reports decode error.
