### PR TITLE
Fix broken Gravatar URL generation

### DIFF
--- a/library/Zend/View/Helper/Gravatar.php
+++ b/library/Zend/View/Helper/Gravatar.php
@@ -310,7 +310,7 @@ class Zend_View_Helper_Gravatar extends Zend_View_Helper_HtmlElement
     {
         $src = $this->_getGravatarUrl()
              . '/'
-             . md5(strtolower($this->getEmail()))
+             . md5(strtolower(trim($this->getEmail())))
              . '?s='
              . $this->getImgSize()
              . '&d='


### PR DESCRIPTION
Gravatar URL's should make use of a trimmed and lowercased email address. This patch implements the correct hashing method as per the official implementation guide at https://en.gravatar.com/site/implement/hash/.
