### PR TITLE
Suggested fix for issue #345 to avoid warnings

### DIFF
--- a/library/Zend/Stdlib/CallbackHandler.php
+++ b/library/Zend/Stdlib/CallbackHandler.php
@@ -101,7 +101,10 @@ class Zend_Stdlib_CallbackHandler
         }
 
         // If pecl/weakref is not installed, simply store the callback and return
-        if (!class_exists('WeakRef')) {
+        set_error_handler(array($this, 'errorHandler'), E_WARNING);
+        $callable = class_exists('WeakRef');
+        restore_error_handler();
+        if (!$callable || $this->error) {
             $this->callback = $callback;
             return;
         }


### PR DESCRIPTION
Catch Warning for non existing WeakRef-extension, see https://github.com/zendframework/zf1/issues/345.
