### PR TITLE
Reduce the number of directories distributed in the composer archive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,8 @@
     "require-dev": {
         "phpunit/phpunit": "3.7.*",
         "phpunit/dbunit": "1.3.*"
+    },
+    "archive": {
+        "exclude": ["/demos", "/documentation", "/tests"]
     }
 }


### PR DESCRIPTION
Currently, the archive version of ZF1 when distributed is 119MB. When using it on our build server, it is absolutely killing us for disk space. Multiple builds each having their own copy, plus a Satis mirror taking all the revisions, it can quickly chew through multiple gigabytes.

For comparison, ZF2 core is ~ 19MB, Symfony 2 is ~ 16MB. 

For a distributable archive, this it is unacceptable to be over 5 times bigger than it's closest comparisons. 

This patch tells composer to ignore directories that shouldn't be needed when consuming the framework as a dependency of your code, and makes mirroring them via Satis much more succinct. It reduces the size of the archive down to 50MB, which while large is less than 1/2 the current size.

These directories are fine to be consumed "in development mode" when you've checked out from github.com, but as a distribution they are unnecessary.

By accepting this Pull Request and tagging a new release this will help us not have a constant battle with build machines running out of disk space.

Thanks,
