### PR TITLE
Corrected type of property _currentRoute

### DIFF
--- a/library/Zend/Controller/Router/Rewrite.php
+++ b/library/Zend/Controller/Router/Rewrite.php
@@ -55,7 +55,7 @@ class Zend_Controller_Router_Rewrite extends Zend_Controller_Router_Abstract
     /**
      * Currently matched route
      *
-     * @var Zend_Controller_Router_Route_Interface
+     * @var string
      */
     protected $_currentRoute = null;
 
@@ -340,7 +340,7 @@ class Zend_Controller_Router_Rewrite extends Zend_Controller_Router_Abstract
      * Retrieve a name of currently matched route
      *
      * @throws Zend_Controller_Router_Exception
-     * @return Zend_Controller_Router_Route_Interface Route object
+     * @return string
      */
     public function getCurrentRouteName()
     {


### PR DESCRIPTION
The (name) matched route is stored in the _currentRoute property (https://github.com/zendframework/zf1/blob/master/library/Zend/Controller/Router/Rewrite.php#L400), which is a string. It can then be retrieved using getCurrentRoute() which returns the route interface. Renaming the _currentRoute property to _currentRouteName would be a BC-break.
