### PR TITLE
Zend_Console_Getopt: Missing required parameter consumes next option as its parameter value

### DIFF
--- a/library/Zend/Console/Getopt.php
+++ b/library/Zend/Console/Getopt.php
@@ -731,26 +731,17 @@ class Zend_Console_Getopt
         return $this;
     }
     
-    public function checkRequiredArguments(){
-        
-        
-        foreach($this->_rules as $name=>$rule){
-            
-            if($rule['param'] === 'required'){
-                
-                $defined = false;
-                
-                foreach($rule['alias'] as $alias){
-                    
-                    $defined = $defined === true ? true : array_key_exists($alias, $this->_options);
-                    
+    public function checkRequiredArguments()
+    {    
+        foreach ($this->_rules as $name=>$rule){           
+            if ($rule['param'] === 'required'){                
+                $defined = false;                
+                foreach ($rule['alias'] as $alias){                    
+                    $defined = $defined === true ? true : array_key_exists($alias, $this->_options);                    
                 }
-                if($defined === false){
-                    
+                if ($defined === false){                    
                     require_once 'Zend/Console/Getopt/Exception.php';
-                    throw new Zend_Console_Getopt_Exception(
-                        "Option \"$alias\" requires a parameter.",
-                            $this->getUsageMessage());
+                    throw new Zend_Console_Getopt_Exception("Option \"$alias\" requires a parameter.", $this->getUsageMessage());
                     
                 }
             }            

--- a/tests/Zend/Console/GetoptTest.php
+++ b/tests/Zend/Console/GetoptTest.php
@@ -269,51 +269,40 @@ class Zend_Console_GetoptTest extends PHPUnit_Framework_TestCase
         $this->assertFalse(isset($opts->a));
     }
     
-    public function testVerifyRequiredArgument(){
-        $opts = new Zend_Console_Getopt(array(
-            'apple|a=s' =>"First required argument"
-        ));
+    public function testVerifyRequiredArgument()
+    {
+        $opts = new Zend_Console_Getopt(array('apple|a=s' => "First required argument"));
         try {   
             $opts->parse();
             $opts->checkRequiredArguments();
             $this->fail('Expected to catch a Zend_Console_Getopt_Exception');
         }
-        catch (Exception $e){
+        catch (Zend_Exception $e){
             $this->assertTrue($e instanceof Zend_Console_Getopt_Exception,
-                'Expected Zend_Console_Getopt_Exception, got '. get_class($e));
-            
-            $this->assertEquals( 'Option "a" requires a parameter.' , $e->getMessage() );
+                'Expected Zend_Console_Getopt_Exception, got '. get_class($e));            
+            $this->assertEquals('Option "a" requires a parameter.' , $e->getMessage());
         }        
         
-        $opts->addArguments( array( "-a", "apple") );
+        $opts->addArguments(array( "-a", "apple") );
         $opts->parse();
         $opts->checkRequiredArguments();//-> no Exception here
     }
     
-    public function testEmptyRequiredOption(){
-        
+    public function testEmptyRequiredOption()
+    {       
         $opts = new Zend_Console_Getopt(array(
             'apple|a=s' =>"First required argument",
             'banana|b=i'  =>"Second required argument"
-        ));
-        
-        $opts->addArguments(array(
-                "-a",
-                "-b",
-                "123"
-        ));
-            
+        ));        
+        $opts->addArguments(array("-a","-b","123"));
         try {   
             $opts->parse();
             $opts->checkRequiredArguments();
-            $this->fail('Expected to catch a Zend_Console_Getopt_Exception');
-             
-         } catch (Exception $e) {             
-             
+            $this->fail('Expected to catch a Zend_Console_Getopt_Exception');             
+         } catch (Zend_Exception $e) {                          
             $this->assertTrue($e instanceof Zend_Console_Getopt_Exception,
-                'Expected Zend_Console_Getopt_Exception, got '. get_class($e));
-            
-            $this->assertEquals( 'Option "a" requires a parameter.' , $e->getMessage() );
+                'Expected Zend_Console_Getopt_Exception, got '. get_class($e));            
+            $this->assertEquals('Option "a" requires a parameter.' , $e->getMessage());
          }
     }
 


### PR DESCRIPTION
Hello here, 

Following up on bug https://github.com/zendframework/zf1/issues/377#issuecomment-46233687 , 
I created an easy fix for the moment. 

I wanted to make the function checkRequiredArguments private, and automatically call it  at the end of teh parse() function, but this breaks few tests because these tests assume a required value can be null.

2 tests are added : 

_testVerifyRequiredArgument()_  test the public function verifyRequiredArguments()

and  _testEmptyRequiredOption()_ shows the correct behavior.
