### PR TITLE
Sending APNS without sound

### DIFF
--- a/library/Zend/Mobile/Push/Apns.php
+++ b/library/Zend/Mobile/Push/Apns.php
@@ -305,7 +305,10 @@ class Zend_Mobile_Push_Apns extends Zend_Mobile_Push_Abstract
         if (!is_null($message->getBadge())) {
             $payload['aps']['badge'] = $message->getBadge();
         }
-        $payload['aps']['sound'] = $message->getSound();
+        $sound = $message->getSound();
+        if (!empty($sound)) {
+            $payload['aps']['sound'] = $sound;
+        }
 
         foreach($message->getCustomData() as $k => $v) {
             $payload[$k] = $v;


### PR DESCRIPTION
If I want to send APNS without sound - it should be without option "sound" in a dictionary.
See https://developer.apple.com/library/mac/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html, Table 3-1.
