### PR TITLE
Fixes Issue #465 Zend_Currency creates invalid cache ids for values with...

### DIFF
--- a/library/Zend/Locale/Data.php
+++ b/library/Zend/Locale/Data.php
@@ -327,7 +327,11 @@ class Zend_Locale_Data
         }
 
         $val = urlencode($val);
-        $id = strtr('Zend_LocaleL_' . $locale . '_' . $path . '_' . $val, array('-' => '_', '%' => '_', '+' => '_', '.' => '_'));
+        $id = strtr(
+            'Zend_LocaleL_' . $locale . '_' . $path . '_' . $val,
+            array('-' => '_', '%' => '_', '+' => '_', '.' => '_')
+        );
+
         if (!self::$_cacheDisabled && ($result = self::$_cache->load($id))) {
             return unserialize($result);
         }


### PR DESCRIPTION
.Fixes Issue #465 Zend_Currency creates invalid cache ids for values with fractions.

Zend_Locale_Data should escape the dot.
