### PR TITLE
Zend_Validate_EmailAddress: IDN domains are converted to punnycode if possible

### DIFF
--- a/library/Zend/Validate/EmailAddress.php
+++ b/library/Zend/Validate/EmailAddress.php
@@ -449,7 +449,14 @@ class Zend_Validate_EmailAddress extends Zend_Validate_Abstract
     private function _validateMXRecords()
     {
         $mxHosts = array();
-        $result = getmxrr($this->_hostname, $mxHosts);
+        $hostname = $this->_hostname;
+
+        //decode IDN domain name if possible
+        if (function_exists('idn_to_ascii')) {
+            $hostname = idn_to_ascii($this->_hostname);
+        }
+
+        $result = getmxrr($hostname, $mxHosts);
         if (!$result) {
             $this->_error(self::INVALID_MX_RECORD);
         } else if ($this->_options['deep'] && function_exists('checkdnsrr')) {

--- a/tests/Zend/Validate/EmailAddressTest.php
+++ b/tests/Zend/Validate/EmailAddressTest.php
@@ -622,6 +622,19 @@ class Zend_Validate_EmailAddressTest extends PHPUnit_Framework_TestCase
         $hostname = $this->_validator->getHostnameValidator();
         $this->assertTrue($hostname instanceof Zend_Validate_Hostname);
     }
+
+    /**
+     * @group GH-62
+     */
+    public function testIdnHostnameInEmaillAddress()
+    {
+        if (version_compare(PHP_VERSION, '5.3.0', '<')) {
+            $this->markTestSkipped('idn_to_ascii() is available in intl in PHP 5.3.0+');
+        }
+        $validator = new Zend_Validate_EmailAddress();
+        $validator->setValidateMx(true);
+        $this->assertTrue($validator->isValid('testmail@detrèsbonsdomaines.com'));
+    }
 }
 
 if (PHPUnit_MAIN_METHOD == 'Zend_Validate_EmailAddressTest::main') {


### PR DESCRIPTION
Fixes #62

The problem is that IDN domain cannot be converted to `xn--` in PHP 5.2 (there are some PHP libraries, that implement it, but we can't include them in ZF). So this is rather a "progressive enhacement" for PHP 5.3+ (with intl enabled)

cc @froschdesign 