### PR TITLE
Fixed build init for hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   - mysql -e 'create database zftest;'
   - psql -c 'create database zftest;' -U postgres
 
-  - if [[ "$TRAVIS_PHP_VERSION" != "5.2" ]]; then phpenv config-add tests/config.ini; fi
+  - if [[ "$TRAVIS_PHP_VERSION" != "5.2" ]] && [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-add tests/config.ini; fi
   - if [[ "$TRAVIS_PHP_VERSION" == "5.2" ]]; then phpenv config-add tests/php52_config.ini; fi
 
   - cp ./tests/TestConfiguration.travis.php ./tests/TestConfiguration.php


### PR DESCRIPTION
hhvm did not start before because of:

```
$ if [[ "$TRAVIS_PHP_VERSION" != "5.2" ]]; then phpenv config-add tests/config.ini; fi
cp: cannot create regular file `/home/travis/.phpenv/versions/hhvm/etc/conf.d': No such file or directory
```
