### PR TITLE
Fixes #475 - Enhance Zend_Server_Exception message

### DIFF
--- a/library/Zend/Json/Server.php
+++ b/library/Zend/Json/Server.php
@@ -550,7 +550,7 @@ class Zend_Json_Server extends Zend_Server_Abstract
                     $orderedParams[ $refParam->getName() ] = $refParam->getDefaultValue();
                 } else {
                     throw new Zend_Server_Exception(
-                        'Missing required parameter: ' . $refParam->getName()
+                        'Method ' . $request->getMethod() .  'is missing required parameter: ' . $refParam->getName()
                     );
                 }
             }

--- a/library/Zend/Json/Server.php
+++ b/library/Zend/Json/Server.php
@@ -550,7 +550,7 @@ class Zend_Json_Server extends Zend_Server_Abstract
                     $orderedParams[ $refParam->getName() ] = $refParam->getDefaultValue();
                 } else {
                     throw new Zend_Server_Exception(
-                        'Method ' . $request->getMethod() .  'is missing required parameter: ' . $refParam->getName()
+                        'Method ' . $request->getMethod() .  ' is missing required parameter: ' . $refParam->getName()
                     );
                 }
             }

--- a/tests/Zend/Json/ServerTest.php
+++ b/tests/Zend/Json/ServerTest.php
@@ -29,6 +29,7 @@ require_once 'Zend/Json/Server.php';
 require_once 'Zend/Json/Server/Request.php';
 require_once 'Zend/Json/Server/Response.php';
 require_once 'Zend/Json.php';
+require_once 'Zend/Server/Exception.php';
 
 /**
  * Test class for Zend_Json_Server
@@ -308,6 +309,22 @@ class Zend_Json_ServerTest extends PHPUnit_Framework_TestCase
         $this->assertNull($result[2]);
     }
 
+    public function testHandleValidMethodWithMissingParamsShouldThrowException()
+    {
+        $this->server->setClass('Zend_Json_ServerTest_Foo')
+            ->setAutoEmitResponse(false);
+        $request = $this->server->getRequest();
+        $request->setMethod('bar')
+            ->setParams(array('one' => null))
+            ->setId('foo');
+        try {
+            $response = $this->server->handle();
+        } catch (Exception $e) {
+            $this->assertTrue($e instanceof Zend_Server_Exception);
+            $this->assertEquals('Method bar is missing required parameter: one', $e->getMessage());
+        }
+    }
+
     public function testHandleValidMethodWithTooManyParamsShouldWork()
     {
         $this->server->setClass('Zend_Json_ServerTest_Foo')
@@ -478,7 +495,7 @@ class Zend_Json_ServerTest_Foo
     public function bar($one, $two = 'two', $three = null)
     {
         return array($one, $two, $three);
-    }    
+    }
 
     /**
      * Baz


### PR DESCRIPTION
Fixes Issue #475.
Zend_Server_Exception should include the method name for easier debugging since it is not captured in the stack trace