### PR TITLE
Some HTTP headers missing in CGI environment

### DIFF
--- a/library/Zend/Controller/Request/Http.php
+++ b/library/Zend/Controller/Request/Http.php
@@ -986,8 +986,10 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
         }
 
         // Try to get it from the $_SERVER array first
-        $temp = 'HTTP_' . strtoupper(str_replace('-', '_', $header));
-        if (isset($_SERVER[$temp])) {
+        $temp = strtoupper(str_replace('-', '_', $header));
+        if (isset($_SERVER['HTTP_' . $temp])) {
+            return $_SERVER['HTTP_' . $temp];
+        } else if /* CGI env */ (isset($_SERVER[$temp]) && in_array($temp, array('CONTENT_TYPE', 'CONTENT_LENGTH'))) {
             return $_SERVER[$temp];
         }
 


### PR DESCRIPTION
`Zend_Controller_Request_Http -> getHeader` fails to find `Content-Type` at least in Apache, when run in a CGI environment (e.g. using php-fpm) and the Apache Environment is unavailable as a fallback.

The following patch works for me.