### PR TITLE
Installs PHPUnit via apt-get instead of via PEAR.

### DIFF
--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -7,7 +7,7 @@ exec { "apt-update" :
 }
 
 # install vim and all packages required to build PHP
-$packages = [ "vim", "curl", "libxpm-dev", "libmcrypt-dev", "libbz2-dev", "libcurl4-gnutls-dev", "libjpeg62-dev", "libpng12-dev", "libfreetype6-dev", "libt1-dev", "libgmp3-dev", "libmysqlclient-dev", "libpq-dev", "libpcre3-dev", "libxml2-dev", "libxslt-dev", "make"]
+$packages = [ "vim", "curl", "libxpm-dev", "libmcrypt-dev", "libbz2-dev", "libcurl4-gnutls-dev", "libjpeg62-dev", "libpng12-dev", "libfreetype6-dev", "libt1-dev", "libgmp3-dev", "libmysqlclient-dev", "libpq-dev", "libpcre3-dev", "libxml2-dev", "libxslt-dev", "make", "phpunit"]
 
 package { $packages :
     ensure => installed,

--- a/puppet/scripts/php-build.sh
+++ b/puppet/scripts/php-build.sh
@@ -76,15 +76,9 @@ make -j 5
 echo "Installing ${VERSION}${POSTFIX} in $PHP_DIR"
 sudo make install
 
-echo "Installing PHPUnit"
-export PATH=/usr/local/php/${VERSION}/bin:/usr/local/bin:/usr/bin:/bin:/vagrant/puppet/scripts
-sudo pear update-channels
-sudo pear upgrade-all
-sudo pear config-set auto_discover 1
-sudo pear install pear.phpunit.de/PHPUnit-3.4.15
-
+echo "Linking PHPUnit library"
+sudo ln -s /usr/share/php/PHPUnit /usr/local/php/${VERSION}${POSTFIX}/lib/php/PHPUnit
 
 echo ""
 echo "PHP version ${VERSION} is now installed. Type: pe ${VERSION}"
 echo ""
-


### PR DESCRIPTION
Fixes #493 