### PR TITLE
Installs PDO_DBLIB driver for SQL Server and configures Pdo_Mssql tests

### DIFF
--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -7,7 +7,7 @@ exec { "apt-update" :
 }
 
 # install vim and all packages required to build PHP
-$packages = [ "vim", "curl", "libxpm-dev", "libmcrypt-dev", "libbz2-dev", "libcurl4-gnutls-dev", "libjpeg62-dev", "libpng12-dev", "libfreetype6-dev", "libt1-dev", "libgmp3-dev", "libmysqlclient-dev", "libpq-dev", "libpcre3-dev", "libxml2-dev", "libxslt-dev", "make", "phpunit"]
+$packages = [ "vim", "curl", "libxpm-dev", "libmcrypt-dev", "libbz2-dev", "libcurl4-gnutls-dev", "libjpeg62-dev", "libpng12-dev", "libfreetype6-dev", "libt1-dev", "libgmp3-dev", "libmysqlclient-dev", "libpq-dev", "libpcre3-dev", "libxml2-dev", "libxslt-dev", "make", "phpunit", "freetds-dev"]
 
 package { $packages :
     ensure => installed,

--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -7,7 +7,7 @@ exec { "apt-update" :
 }
 
 # install vim and all packages required to build PHP
-$packages = [ "vim", "curl", "libxpm-dev", "libmcrypt-dev", "libbz2-dev", "libcurl4-gnutls-dev", "libjpeg62-dev", "libpng12-dev", "libfreetype6-dev", "libt1-dev", "libgmp3-dev", "libmysqlclient-dev", "libpq-dev", "libpcre3-dev", "libxml2-dev", "libxslt-dev", "make"]
+$packages = [ "vim", "curl", "libxpm-dev", "libmcrypt-dev", "libbz2-dev", "libcurl4-gnutls-dev", "libjpeg62-dev", "libpng12-dev", "libfreetype6-dev", "libt1-dev", "libgmp3-dev", "libmysqlclient-dev", "libpq-dev", "libpcre3-dev", "libxml2-dev", "libxslt-dev", "make", "phpunit"]
 
 package { $packages :
     ensure => installed,

--- a/puppet/scripts/php-build.sh
+++ b/puppet/scripts/php-build.sh
@@ -76,15 +76,9 @@ make -j 5
 echo "Installing ${VERSION}${POSTFIX} in $PHP_DIR"
 sudo make install
 
-echo "Installing PHPUnit"
-export PATH=/usr/local/php/${VERSION}/bin:/usr/local/bin:/usr/bin:/bin:/vagrant/puppet/scripts
-sudo pear update-channels
-sudo pear upgrade-all
-sudo pear config-set auto_discover 1
-sudo pear install pear.phpunit.de/PHPUnit-3.4.15
-
+echo "Linking PHPUnit library"
+sudo ln -s /usr/share/php/PHPUnit /usr/local/php/${VERSION}${POSTFIX}/lib/php/PHPUnit
 
 echo ""
 echo "PHP version ${VERSION} is now installed. Type: pe ${VERSION}"
 echo ""
-

--- a/puppet/scripts/php-build.sh
+++ b/puppet/scripts/php-build.sh
@@ -65,7 +65,7 @@ OPTIONS="--with-gd --with-jpeg-dir=/usr --with-xpm-dir=/usr --with-freetype-dir=
     --enable-spl --enable-pdo --with-pdo-mysql --with-pdo-sqlite \
     --with-ctype --with-bz2 --enable-mbstring --with-mime-magic \
     --with-xmlrpc --with-zlib --disable-zend-memory-manager --with-esmtp \
-    --with-xsl --enable-exif --enable-soap --enable-ftp"
+    --with-xsl --enable-exif --enable-soap --enable-ftp --with-pdo-dblib"
 
 ./configure --prefix=/usr/local/php/${VERSION}${POSTFIX} ${EXTRA_FLAGS} ${OPTIONS}
 

--- a/tests/Zend/Db/AllTests.php
+++ b/tests/Zend/Db/AllTests.php
@@ -116,6 +116,9 @@ class Zend_Db_AllTests
 
             // check the PDO driver is available
             $pdo_driver = strtolower($matches[1]);
+            if ('mssql' == $pdo_driver) { // ZF-499
+                $pdo_driver = 'dblib';
+            }
             if (!in_array($pdo_driver, PDO::getAvailableDrivers())) {
                 self::_skipTestSuite($driver, "PDO driver '{$pdo_driver}' is not available");
                 return;

--- a/tests/Zend/Db/TestUtil/Pdo/Mssql.php
+++ b/tests/Zend/Db/TestUtil/Pdo/Mssql.php
@@ -85,24 +85,24 @@ class Zend_Db_TestUtil_Pdo_Mssql extends Zend_Db_TestUtil_Pdo_Common
 
     protected function _getSqlCreateTable($tableName)
     {
-        $sql = "exec sp_tables @table_name = " . $this->_db->quoteIdentifier($tableName, true);
-        $stmt = $this->_db->query($sql);
+        $sql = "exec sp_tables @table_name = " . $this->getAdapter()->quoteIdentifier($tableName, true);
+        $stmt = $this->getAdapter()->query($sql);
         $tableList = $stmt->fetchAll(Zend_Db::FETCH_ASSOC);
 
         if (count($tableList) > 0 && $tableName == $tableList[0]['TABLE_NAME']) {
             return null;
         }
-        return 'CREATE TABLE ' . $this->_db->quoteIdentifier($tableName);
+        return 'CREATE TABLE ' . $this->getAdapter()->quoteIdentifier($tableName);
     }
 
     private function _getSqlDropElement($elementName, $typeElement = 'TABLE')
     {
-        $sql = "exec sp_tables @table_name = " . $this->_db->quoteIdentifier($elementName, true);
-        $stmt = $this->_db->query($sql);
+        $sql = "exec sp_tables @table_name = " . $this->getAdapter()->quoteIdentifier($elementName, true);
+        $stmt = $this->getAdapter()->query($sql);
         $elementList = $stmt->fetchAll(Zend_Db::FETCH_ASSOC);
 
         if (count($elementList) > 0 && $elementName == $elementList[0]['TABLE_NAME']) {
-            return "DROP $typeElement " . $this->_db->quoteIdentifier($elementName);
+            return "DROP $typeElement " . $this->getAdapter()->quoteIdentifier($elementName);
         }
         return null;
     }

--- a/tests/Zend/Db/TestUtil/Pdo/Mssql.php
+++ b/tests/Zend/Db/TestUtil/Pdo/Mssql.php
@@ -48,7 +48,10 @@ class Zend_Db_TestUtil_Pdo_Mssql extends Zend_Db_TestUtil_Pdo_Common
             'port'     => 'TESTS_ZEND_DB_ADAPTER_PDO_MSSQL_PORT'
         );
 
-        return parent::getParams($constants);
+        $params = parent::getParams($constants);
+        $params['pdoType'] = 'dblib';
+
+        return $params;
     }
 
     public function getSqlType($type)


### PR DESCRIPTION
Fixes #499 

Thanks to @ollieparsley for instructions on how to install PDO_DBLIB on Ubuntu and compile PHP for supporting it -- http://ollieparsley.com/2014/05/29/linux-php-pdo-sql-server/

Once unit tests are intended to run on development VM, which is Ubuntu, the `pdoType` adapter option was set to `dblib` where needed.