### PR TITLE
Fix ZF-7570: forceIndex, useIndex methods on db select.

### DIFF
--- a/library/Zend/Db/Select.php
+++ b/library/Zend/Db/Select.php
@@ -55,6 +55,9 @@ class Zend_Db_Select
     const LIMIT_COUNT    = 'limitcount';
     const LIMIT_OFFSET   = 'limitoffset';
     const FOR_UPDATE     = 'forupdate';
+    const USE_INDEX      = 'useIndex';
+    const FORCE_INDEX    = 'forceIndex';
+    const IGNORE_INDEX   = 'ignoreIndex';
 
     const INNER_JOIN     = 'inner join';
     const LEFT_JOIN      = 'left join';
@@ -80,6 +83,9 @@ class Zend_Db_Select
     const SQL_ON         = 'ON';
     const SQL_ASC        = 'ASC';
     const SQL_DESC       = 'DESC';
+    const SQL_USE_INDEX  = 'USE INDEX';
+    const SQL_FORCE_INDEX = 'FORCE INDEX';
+    const SQL_IGNORE_INDEX = 'IGNORE INDEX';
 
     /**
      * Bind variables for query
@@ -107,6 +113,9 @@ class Zend_Db_Select
         self::COLUMNS      => array(),
         self::UNION        => array(),
         self::FROM         => array(),
+        self::USE_INDEX    => array(),
+        self::FORCE_INDEX  => array(),
+        self::IGNORE_INDEX  => array(),
         self::WHERE        => array(),
         self::GROUP        => array(),
         self::HAVING       => array(),
@@ -1130,6 +1139,20 @@ class Zend_Db_Select
             $tmp .= $this->_getQuotedSchema($table['schema']);
             $tmp .= $this->_getQuotedTable($table['tableName'], $correlationName);
 
+            // Add use index statement after FROM, before joins (if applicable)
+            if (!empty($this->_parts[self::USE_INDEX])) {
+                $tmp .= ' ' . self::SQL_USE_INDEX . '(' . implode(',', $this->_parts[self::USE_INDEX]) . ')';
+                unset($this->_parts[self::USE_INDEX]);
+            }
+            if (!empty($this->_parts[self::FORCE_INDEX])) {
+                $tmp .= ' ' . self::SQL_FORCE_INDEX . '(' . implode(',', $this->_parts[self::FORCE_INDEX]) . ')';
+                unset($this->_parts[self::FORCE_INDEX]);
+            }
+            if (!empty($this->_parts[self::IGNORE_INDEX])) {
+                $tmp .= ' ' . self::SQL_IGNORE_INDEX . '(' . implode(',', $this->_parts[self::IGNORE_INDEX]) . ')';
+                unset($this->_parts[self::IGNORE_INDEX]);
+            }
+
             // Add join conditions (if applicable)
             if (!empty($from) && ! empty($table['joinCondition'])) {
                 $tmp .= ' ' . self::SQL_ON . ' ' . $table['joinCondition'];
@@ -1351,6 +1374,51 @@ class Zend_Db_Select
             $sql = '';
         }
         return (string)$sql;
+    }
+
+    /**
+     * Specify index to use. Works only on mysql
+     *
+     * @param string $index
+     * @return Zend_Db_Select
+     */
+    public function useIndex($index)
+    {
+        if (!is_array($index)) {
+            $index = array($index);
+        }
+        $this->_parts[self::USE_INDEX] = $index;
+        return $this;
+    }
+
+    /**
+     * Force index. Works only on mysql
+     *
+     * @param string $index
+     * @return Zend_Db_Select
+     */
+    public function forceIndex($index)
+    {
+        if (!is_array($index)) {
+            $index = array($index);
+        }
+        $this->_parts[self::FORCE_INDEX] = $index;
+        return $this;
+    }
+
+    /**
+     * Ignore index. Works only on mysql
+     *
+     * @param string $index
+     * @return Zend_Db_Select
+     */
+    public function ignoreIndex($index)
+    {
+        if (!is_array($index)) {
+            $index = array($index);
+        }
+        $this->_parts[self::IGNORE_INDEX] = $index;
+        return $this;
     }
 
 }

--- a/tests/Zend/Db/Select/Pdo/MysqlTest.php
+++ b/tests/Zend/Db/Select/Pdo/MysqlTest.php
@@ -47,4 +47,53 @@ class Zend_Db_Select_Pdo_MysqlTest extends Zend_Db_Select_TestCommon
         return 'Pdo_Mysql';
     }
 
+    public function testSelectWithForceIndex()
+    {
+        $select = $this->_db->select();
+        $select->from(array ('p' => 'product'))
+            ->forceIndex('IX_this_index_does_not_exist');
+
+        $expected = 'SELECT `p`.* FROM `product` AS `p` FORCE INDEX(IX_this_index_does_not_exist)';
+        $this->assertEquals($expected, $select->assemble(),
+            'Select with force index failed');
+    }
+
+    public function testSelectWithUseIndex()
+    {
+        $select = $this->_db->select();
+        $select->from(array ('p' => 'product'))
+            ->useIndex('IX_this_index_does_not_exist');
+
+        $expected = 'SELECT `p`.* FROM `product` AS `p` USE INDEX(IX_this_index_does_not_exist)';
+        $this->assertEquals($expected, $select->assemble(),
+            'Select with use index failed');
+    }
+
+    public function testSelectWithIgnoreIndex()
+    {
+        $select = $this->_db->select();
+        $select->from(array ('p' => 'product'))
+            ->ignoreIndex('IX_this_index_does_not_exist');
+
+        $expected = 'SELECT `p`.* FROM `product` AS `p` IGNORE INDEX(IX_this_index_does_not_exist)';
+        $this->assertEquals($expected, $select->assemble(),
+            'Select with ignore index failed');
+    }
+
+    public function testSelectWithJoinAndForceIndex()
+    {
+        $products = $this->_db->quoteIdentifier('zfproducts');
+        $product_id = $this->_db->quoteIdentifier('product_id');
+        $bugs_products = $this->_db->quoteIdentifier('zfbugs_products');
+
+        $select = $this->_db->select()
+            ->from('zfproducts')
+            ->forceIndex('IX_this_index_does_not_exist')
+            ->join('zfbugs_products', "$products.$product_id = $bugs_products.$product_id", array());
+
+        $expected = 'SELECT `zfproducts`.* FROM `zfproducts` FORCE INDEX(IX_this_index_does_not_exist)' .
+            "\n" . ' INNER JOIN `zfbugs_products` ON `zfproducts`.`product_id` = `zfbugs_products`.`product_id`';
+        $this->assertEquals($expected, $select->assemble(),
+            'Select with join and force index failed');
+    }
 }


### PR DESCRIPTION
This addresses issue [ZF-7570](http://framework.zend.com/issues/browse/ZF-7570) also mentioned at #489 and is using code originally provided by Richard John.

Allows for a query like 
```sql
SELECT * FROM table_name FORCE INDEX (index_name) WHERE where_statement;
```
Known Issues:
 1. Code has been implemented and tested for mysql only
 1. Current Implementation works only for indexes on the table used in the FROM part. It can not be used for tables specified at the "JOIN" part
 1. FORCE INDEX, USE INDEX have been implemented. IGNORE INDEX has not been implemented