### PR TITLE
Fix for #511 - Add PATCH to the list of allowed methods in Zend_Controller_Request_HttpTestCase

### DIFF
--- a/library/Zend/Controller/Request/HttpTestCase.php
+++ b/library/Zend/Controller/Request/HttpTestCase.php
@@ -62,6 +62,7 @@ class Zend_Controller_Request_HttpTestCase extends Zend_Controller_Request_Http
         'GET',
         'HEAD',
         'OPTIONS',
+        'PATCH',
         'POST',
         'PUT',
     );


### PR DESCRIPTION
Adds patch to the list of valid method types array.