### PR TITLE
Use different php.ini config for PHP 7 Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,9 @@ before_script:
   - mysql -e 'create database zftest;'
   - psql -c 'create database zftest;' -U postgres
 
-  - if [[ "$TRAVIS_PHP_VERSION" != "5.2" ]] && [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-add tests/config.ini; fi
+  - if [[ "$TRAVIS_PHP_VERSION" != "5.2" ]] && [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]] && [[ "$TRAVIS_PHP_VERSION" != "7" ]]; then phpenv config-add tests/config.ini; fi
   - if [[ "$TRAVIS_PHP_VERSION" == "5.2" ]]; then phpenv config-add tests/php52_config.ini; fi
+  - if [[ "$TRAVIS_PHP_VERSION" == "7" ]]; then phpenv config-add tests/php7_config.ini; fi
 
   - cp ./tests/TestConfiguration.travis.php ./tests/TestConfiguration.php
 


### PR DESCRIPTION
Ref #518 

This PR prevents Travis PHP 7 builds from failing because of missing memcache(d) extensions