### PR TITLE
Fix PHP 7 BC breaks in Zend_XmlRpc/Amf_Server

### DIFF
--- a/library/Zend/Amf/Server.php
+++ b/library/Zend/Amf/Server.php
@@ -767,9 +767,9 @@ class Zend_Amf_Server implements Zend_Server_Interface
             throw new Zend_Amf_Server_Exception('Invalid method or class; must be a classname or object');
         }
 
-        $argv = null;
+        $args = null;
         if (2 < func_num_args()) {
-            $argv = array_slice(func_get_args(), 2);
+            $args = array_slice(func_get_args(), 2);
         }
 
         // Use the class name as the name space by default.
@@ -780,7 +780,7 @@ class Zend_Amf_Server implements Zend_Server_Interface
 
         $this->_classAllowed[is_object($class) ? get_class($class) : $class] = true;
 
-        $this->_methods[] = Zend_Server_Reflection::reflectClass($class, $argv, $namespace);
+        $this->_methods[] = Zend_Server_Reflection::reflectClass($class, $args, $namespace);
         $this->_buildDispatchTable();
 
         return $this;

--- a/library/Zend/XmlRpc/Server.php
+++ b/library/Zend/XmlRpc/Server.php
@@ -278,13 +278,13 @@ class Zend_XmlRpc_Server extends Zend_Server_Abstract
             throw new Zend_XmlRpc_Server_Exception('Invalid method class', 610);
         }
 
-        $argv = null;
+        $args = null;
         if (2 < func_num_args()) {
-            $argv = func_get_args();
-            $argv = array_slice($argv, 2);
+            $args = func_get_args();
+            $args = array_slice($args, 2);
         }
 
-        $dispatchable = Zend_Server_Reflection::reflectClass($class, $argv, $namespace);
+        $dispatchable = Zend_Server_Reflection::reflectClass($class, $args, $namespace);
         foreach ($dispatchable->getMethods() as $reflection) {
             $this->_buildSignature($reflection, $class);
         }


### PR DESCRIPTION
> The func_get_arg() and func_get_args() functions will no longer return the
>  original value that was passed to a parameter and will instead provide the
> current value (which might have been modified).

(from https://github.com/php/php-src/blob/master/UPGRADING)

See http://3v4l.org/HvCqN for example of changed behaviour
