### PR TITLE
Allow early suppressing of file not found warnings in Zend_Application

### DIFF
--- a/library/Zend/Application.php
+++ b/library/Zend/Application.php
@@ -70,15 +70,17 @@ class Zend_Application
      *
      * @param  string                   $environment
      * @param  string|array|Zend_Config $options String path to configuration file, or array/Zend_Config of configuration options
+     * @param bool $suppressNotFoundWarnings Should warnings be suppressed when a file is not found during autoloading?
      * @throws Zend_Application_Exception When invalid options are provided
      * @return void
      */
-    public function __construct($environment, $options = null)
+    public function __construct($environment, $options = null, $suppressNotFoundWarnings = null)
     {
         $this->_environment = (string) $environment;
 
         require_once 'Zend/Loader/Autoloader.php';
         $this->_autoloader = Zend_Loader_Autoloader::getInstance();
+        $this->_autoloader->suppressNotFoundWarnings($suppressNotFoundWarnings);
 
         if (null !== $options) {
             if (is_string($options)) {

--- a/tests/Zend/Application/ApplicationTest.php
+++ b/tests/Zend/Application/ApplicationTest.php
@@ -108,6 +108,33 @@ class Zend_Application_ApplicationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($options, $application->getOptions());
     }
 
+    /**
+     * @group GH-564
+     * @depends testConstructorInstantiatesAutoloader
+     */
+    public function testConstructorRespectsSuppressFileNotFoundWarningFlag()
+    {
+        $application = new Zend_Application('testing');
+        $this->assertFalse($application->getAutoloader()->suppressNotFoundWarnings()); //Default value
+
+        $application = new Zend_Application('testing', null, $suppressNotFoundWarnings = true);
+        $this->assertTrue($application->getAutoloader()->suppressNotFoundWarnings());
+
+        $application = new Zend_Application('testing', null, $suppressNotFoundWarnings = false);
+        $this->assertFalse($application->getAutoloader()->suppressNotFoundWarnings());
+
+        $options = array(
+            'foo' => 'bar',
+            'bar' => 'baz',
+        );
+
+        $application = new Zend_Application('testing', $options, $suppressNotFoundWarnings = true);
+        $this->assertTrue($application->getAutoloader()->suppressNotFoundWarnings());
+
+        $application = new Zend_Application('testing', $options, $suppressNotFoundWarnings = false);
+        $this->assertFalse($application->getAutoloader()->suppressNotFoundWarnings());
+    }
+
     public function testHasOptionShouldReturnFalseWhenOptionNotPresent()
     {
         $this->assertFalse($this->application->hasOption('foo'));


### PR DESCRIPTION
Needed to prevent warnings when the (default) Bootstrap object is set, which will trigger a load of ZendX_Application_Resource_FrontController, as described in https://github.com/zendframework/zf1/issues/564