### PR TITLE
Cast int and float to string when creating headers

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -1592,6 +1592,11 @@ class Zend_Http_Client
             return;
         }
 
+        // Cast integers and floats to strings for purposes of header representation.
+        if (is_int($value) || is_float($value)) {
+            $value = (string) $value;
+        }
+
         if (! is_string($value) && (! is_object($value) || ! method_exists($value, '__toString'))) {
             require_once 'Zend/Http/Exception.php';
             throw new Zend_Http_Exception('Invalid header value detected');

--- a/tests/Zend/Cloud/Infrastructure/Adapter/Ec2Test.php
+++ b/tests/Zend/Cloud/Infrastructure/Adapter/Ec2Test.php
@@ -91,7 +91,13 @@ class Zend_Cloud_Infrastructure_Adapter_Ec2Test extends PHPUnit_Framework_TestCa
      */
     protected function loadResponse($name)
     {
-        return file_get_contents($name);
+        $response = file_get_contents($name);
+
+        // Line endings are sometimes an issue inside the canned responses; the
+        // following is a negative lookbehind assertion, and replaces any \n
+        // not preceded by \r with the sequence \r\n, ensuring that the message
+        // is well-formed.
+        return preg_replace("#(?<!\r)\n#", "\r\n", $response);
     }
     /**
      * Get Config Array

--- a/tests/Zend/Cloud/Infrastructure/Adapter/RackspaceTest.php
+++ b/tests/Zend/Cloud/Infrastructure/Adapter/RackspaceTest.php
@@ -74,8 +74,8 @@ class Zend_Cloud_Infrastructure_Adapter_RackspaceTest extends PHPUnit_Framework_
         
         if (file_exists($filename)) {
             // authentication (from file)
-            $content = file_get_contents(dirname(__FILE__) . '/_files/'.$shortClassName . '_testAuthenticate.response');
-            $this->httpClientAdapterTest->setResponse($content);
+            $content = dirname(__FILE__) . '/_files/'.$shortClassName . '_testAuthenticate.response';
+            $this->httpClientAdapterTest->setResponse($this->loadResponse($content));
             $this->assertTrue($this->infrastructure->getAdapter()->authenticate(),'Authentication failed');
             
             $this->httpClientAdapterTest->setResponse($this->loadResponse($filename)); 
@@ -91,7 +91,13 @@ class Zend_Cloud_Infrastructure_Adapter_RackspaceTest extends PHPUnit_Framework_
      */
     protected function loadResponse($name)
     {
-        return file_get_contents($name);
+        $response = file_get_contents($name);
+
+        // Line endings are sometimes an issue inside the canned responses; the
+        // following is a negative lookbehind assertion, and replaces any \n
+        // not preceded by \r with the sequence \r\n, ensuring that the message
+        // is well-formed.
+        return preg_replace("#(?<!\r)\n#", "\r\n", $response);
     }    
     /**
      * Get Config Array

--- a/tests/Zend/Gdata/App/EntryTest.php
+++ b/tests/Zend/Gdata/App/EntryTest.php
@@ -39,18 +39,29 @@ class Zend_Gdata_App_EntryTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->enryText = file_get_contents(
-                'Zend/Gdata/App/_files/EntrySample1.xml',
-                true);
-        $this->httpEntrySample = file_get_contents(
-                'Zend/Gdata/App/_files/EntrySampleHttp1.txt',
-                true);
+        $this->enryText = $this->loadResponse(
+            dirname(__FILE__) . '/../App/_files/EntrySample1.xml'
+        );
+        $this->httpEntrySample = $this->loadResponse(
+            dirname(__FILE__) . '/../App/_files/EntrySampleHttp1.txt'
+        );
         $this->enry = new Zend_Gdata_App_Entry();
 
         $this->adapter = new Test_Zend_Gdata_MockHttpClient();
         $this->client = new Zend_Gdata_HttpClient();
         $this->client->setAdapter($this->adapter);
         $this->service = new Zend_Gdata_App($this->client);
+    }
+
+    public function loadResponse($filename)
+    {
+        $response = file_get_contents($filename);
+
+        // Line endings are sometimes an issue inside the canned responses; the
+        // following is a negative lookbehind assertion, and replaces any \n
+        // not preceded by \r with the sequence \r\n, ensuring that the message
+        // is well-formed.
+        return preg_replace("#(?<!\r)\n#", "\r\n", $response);
     }
 
     public function testEmptyEntryShouldHaveEmptyExtensionsList()

--- a/tests/Zend/Gdata/AppTest.php
+++ b/tests/Zend/Gdata/AppTest.php
@@ -41,23 +41,34 @@ class Zend_Gdata_AppTest extends PHPUnit_Framework_TestCase
         $this->expectedEtag = 'W/"CkcHQH8_fCp7ImA9WxRTGEw."';
         $this->expectedMajorProtocolVersion = 1;
         $this->expectedMinorProtocolVersion = 2;
-        $this->httpEntrySample = file_get_contents(
-                'Zend/Gdata/_files/AppSample1.txt',
-                true);
-        $this->httpEntrySampleWithoutVersion = file_get_contents(
-                'Zend/Gdata/_files/AppSample2.txt',
-                true);
-        $this->httpFeedSample = file_get_contents(
-                'Zend/Gdata/_files/AppSample3.txt',
-                true);
-        $this->httpFeedSampleWithoutVersion = file_get_contents(
-                'Zend/Gdata/_files/AppSample4.txt',
-                true);
+        $this->httpEntrySample = $this->loadResponse(
+            dirname(__FILE__) . '/_files/AppSample1.txt'
+        );
+        $this->httpEntrySampleWithoutVersion = $this->loadResponse(
+            dirname(__FILE__) . '/_files/AppSample2.txt'
+        );
+        $this->httpFeedSample = $this->loadResponse(
+            dirname(__FILE__) . '/_files/AppSample3.txt'
+        );
+        $this->httpFeedSampleWithoutVersion = $this->loadResponse(
+            dirname(__FILE__) . '/_files/AppSample4.txt'
+        );
 
         $this->adapter = new Test_Zend_Gdata_MockHttpClient();
         $this->client = new Zend_Gdata_HttpClient();
         $this->client->setAdapter($this->adapter);
         $this->service = new Zend_Gdata_App($this->client);
+    }
+
+    public function loadResponse($filename)
+    {
+        $response = file_get_contents($filename);
+
+        // Line endings are sometimes an issue inside the canned responses; the
+        // following is a negative lookbehind assertion, and replaces any \n
+        // not preceded by \r with the sequence \r\n, ensuring that the message
+        // is well-formed.
+        return preg_replace("#(?<!\r)\n#", "\r\n", $response);
     }
 
     public function testImportFile()

--- a/tests/Zend/Gdata/AuthSubTest.php
+++ b/tests/Zend/Gdata/AuthSubTest.php
@@ -221,11 +221,8 @@ class Zend_Gdata_AuthSubTest extends PHPUnit_Framework_TestCase
     public function testGetAuthSubTokenInfoReceivesSuccessfulResult()
     {
         $adapter = new Zend_Http_Client_Adapter_Test();
-        $adapter->setResponse("HTTP/1.1 200 OK
-
-Target=http://example.com
-Scope=http://example.com
-Secure=false");
+        $response = "HTTP/1.1 200 OK\r\n\r\nTarget=http://example.com\nScope=http://example.com\nSecure=false";
+        $adapter->setResponse($response);
         
         $client = new Zend_Gdata_HttpClient();
         $client->setUri('http://example.com/AuthSub');

--- a/tests/Zend/Http/Client/StaticTest.php
+++ b/tests/Zend/Http/Client/StaticTest.php
@@ -689,15 +689,14 @@ class Zend_Http_Client_StaticTest extends PHPUnit_Framework_TestCase
 
         $adapter = $this->_client->getAdapter(); /* @var $adapter Zend_Http_Client_Adapter_Test */
 
-        $adapter->setResponse(<<<RESPONSE
-HTTP/1.1 302 Redirect
-Content-Type: text/html; charset=UTF-8
-Location: /test
-Server: Microsoft-IIS/7.0
-Date: Tue, 19 Apr 2011 11:23:48 GMT
+        $response = "HTTP/1.1 302 Redirect\r\n"
+            . "Content-Type: text/html; charset=UTF-8\r\n"
+            . "Location: /test\r\n"
+            . "Server: Microsoft-IIS/7.0\r\n"
+            . "Date: Tue, 19 Apr 2011 11:23:48 GMT\r\n\r\n"
+            . "RESPONSE";
 
-RESPONSE
-        );
+        $adapter->setResponse($response);
 
         $res = $this->_client->request('GET');
 

--- a/tests/Zend/Http/CookieJarTest.php
+++ b/tests/Zend/Http/CookieJarTest.php
@@ -35,6 +35,16 @@ require_once 'Zend/Http/CookieJar.php';
  */
 class Zend_Http_CookieJarTest extends PHPUnit_Framework_TestCase
 {
+    public function loadResponse($filename)
+    {
+        $message = file_get_contents($filename);
+        // Line endings are sometimes an issue inside the canned responses; the
+        // following is a negative lookbehind assertion, and replaces any \n
+        // not preceded by \r with the sequence \r\n, ensuring that the message
+        // is well-formed.
+        return preg_replace("#(?<!\r)\n#", "\r\n", $message);
+    }
+
     /**
      * Test we can add cookies to the jar
      *
@@ -83,8 +93,9 @@ class Zend_Http_CookieJarTest extends PHPUnit_Framework_TestCase
     public function testAddCookiesFromResponse()
     {
         $jar = new Zend_Http_Cookiejar();
-        $res_str = file_get_contents(dirname(realpath(__FILE__)) .
-            DIRECTORY_SEPARATOR . '_files'  . DIRECTORY_SEPARATOR . 'response_with_cookies');
+        $res_str = $this->loadResponse(
+            dirname(realpath(__FILE__)) . '/_files/response_with_cookies'
+        );
         $response = Zend_Http_Response::fromString($res_str);
 
         $jar->addCookiesFromResponse($response, 'http://www.example.com');
@@ -442,8 +453,9 @@ class Zend_Http_CookieJarTest extends PHPUnit_Framework_TestCase
      */
     public function testFromResponse()
     {
-        $res_str = file_get_contents(dirname(realpath(__FILE__)) .
-            DIRECTORY_SEPARATOR . '_files'  . DIRECTORY_SEPARATOR . 'response_with_single_cookie');
+        $res_str = $this->loadResponse(
+            dirname(realpath(__FILE__)) . '/_files/response_with_single_cookie'
+        );
         $response = Zend_Http_Response::fromString($res_str);
 
         $jar = Zend_Http_CookieJar::fromResponse($response, 'http://www.example.com');
@@ -457,8 +469,9 @@ class Zend_Http_CookieJarTest extends PHPUnit_Framework_TestCase
      */
     public function testFromResponseMultiHeader()
     {
-        $res_str = file_get_contents(dirname(realpath(__FILE__)) .
-            DIRECTORY_SEPARATOR . '_files'  . DIRECTORY_SEPARATOR . 'response_with_cookies');
+        $res_str = $this->loadResponse(
+            dirname(realpath(__FILE__)) . '/_files/response_with_cookies'
+        );
         $response = Zend_Http_Response::fromString($res_str);
 
         $jar = Zend_Http_CookieJar::fromResponse($response, 'http://www.example.com');

--- a/tests/Zend/Service/Audioscrobbler/AudioscrobblerTest.php
+++ b/tests/Zend/Service/Audioscrobbler/AudioscrobblerTest.php
@@ -102,6 +102,11 @@ class Zend_Service_Audioscrobbler_AudioscrobblerTest extends Zend_Service_Audios
 
     public static function readTestResponse($file)
     {
-        return file_get_contents(dirname(__FILE__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . $file);
+        $message = file_get_contents(sprintf('%s/_files/%s', dirname(__FILE__), $file));
+        // Line endings are sometimes an issue inside the canned responses; the
+        // following is a negative lookbehind assertion, and replaces any \n
+        // not preceded by \r with the sequence \r\n, ensuring that the message
+        // is well-formed.
+        return preg_replace("#(?<!\r)\n#", "\r\n", $message);
     }
 }

--- a/tests/Zend/Service/Flickr/OfflineTest.php
+++ b/tests/Zend/Service/Flickr/OfflineTest.php
@@ -534,7 +534,12 @@ class Zend_Service_Flickr_OfflineTest extends PHPUnit_Framework_TestCase
      */
     protected function _loadResponse($name)
     {
-        return file_get_contents("$this->_filesPath/$name.response");
+        $message = file_get_contents(sprintf('%s/%s.response', $this->_filesPath, $name));
+        // Line endings are sometimes an issue inside the canned responses; the
+        // following is a negative lookbehind assertion, and replaces any \n
+        // not preceded by \r with the sequence \r\n, ensuring that the message
+        // is well-formed.
+        return preg_replace("#(?<!\r)\n#", "\r\n", $message);
     }
 }
 


### PR DESCRIPTION
With the ZF2015-04 patch in 1.12.12, we were no longer allowing non-string, non-stringable objects as header values. This broke a number of other classes, however, which required integer and/or float values (e.g., to set a Content-Length header).  This patch casts those types to strings before attempting to set them as header values.