### PR TITLE
ZF2015-06 fix broke the ZF on PHP 5.2

### DIFF
--- a/tests/Zend/Xml/MultibyteTest.php
+++ b/tests/Zend/Xml/MultibyteTest.php
@@ -25,9 +25,12 @@ if (!defined('PHPUnit_MAIN_METHOD')) {
 }
 
 /**
+ * This is a class that overrides Zend_Xml_Security to mark the heuristicScan()
+ * method as public, allowing us to test it.
+ *
  * @see Zend_Xml_Security
  */
-require_once 'Zend/Xml/Security.php';
+require_once 'Zend/Xml/TestAsset/Security.php';
 
 require_once 'Zend/Xml/Exception.php';
 
@@ -80,9 +83,7 @@ XML;
      */
     public function invokeHeuristicScan($xml)
     {
-        $r = new ReflectionMethod('Zend_Xml_Security', 'heuristicScan');
-        $r->setAccessible(true);
-        return $r->invoke(null, $xml);
+        return Zend_Xml_TestAsset_Security::heuristicScan($xml);
     }
 
     /**

--- a/tests/Zend/Xml/TestAsset/Security.php
+++ b/tests/Zend/Xml/TestAsset/Security.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Xml_Security
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @version    $Id$
+ */
+
+require_once 'Zend/Xml/Security.php';
+
+class Zend_Xml_TestAsset_Security extends Zend_Xml_Security
+{
+    /**
+     * Override heuristic scan to make it public for testing.
+     *
+     * @param string $xml
+     * @throws Zend_Xml_Exception If entity expansion or external entity declaration was discovered.
+     */
+    public static function heuristicScan($xml)
+    {
+        parent::heuristicScan($xml);
+    }
+}


### PR DESCRIPTION
There is an anonymous function which is not supported on PHP 5.2 https://github.com/zendframework/zf1/blob/master/library/Zend/Xml/Security.php#L192

(the Travis is failing)

cc @weierophinney 