### PR TITLE
"Invalid header line detected" error if HTTP header value is empty

### DIFF
--- a/library/Zend/Http/Response.php
+++ b/library/Zend/Http/Response.php
@@ -525,7 +525,7 @@ class Zend_Http_Response
             }
 
             // Locate headers like 'Location: ...' and 'Location:...' (note the missing space)
-            if (preg_match("|^([\w-]+):\s*(.+)|s", $line, $m)) {
+            if (preg_match("|^([a-zA-Z0-9\'`#$%&*+.^_\|\~!-]+):\s*(.*)|s", $line, $m)) {
                 unset($last_header);
                 $h_name  = strtolower($m[1]);
                 $h_value = $m[2];
@@ -536,12 +536,12 @@ class Zend_Http_Response
                         $headers[$h_name] = array($headers[$h_name]);
                     }
 
-                    $headers[$h_name][] = $h_value;
+                    $headers[$h_name][] = ltrim($h_value);
                     $last_header = $h_name;
                     continue;
                 }
 
-                $headers[$h_name] = $h_value;
+                $headers[$h_name] = ltrim($h_value);
                 $last_header = $h_name;
                 continue;
             }

--- a/tests/Zend/Http/ResponseTest.php
+++ b/tests/Zend/Http/ResponseTest.php
@@ -415,4 +415,40 @@ class Zend_Http_ResponseTest extends PHPUnit_Framework_TestCase
         $this->setExpectedException('Zend_Http_Exception', 'Invalid');
         Zend_Http_Response::extractHeaders($message);
     }
+
+    /**
+     * @group 587
+     */
+    public function testExtractHeadersShouldAllowAnyValidHttpHeaderToken()
+    {
+        $response = $this->readResponse('response_587');
+        $headers  = Zend_Http_Response::extractHeaders($response);
+
+        $this->assertArrayHasKey('zipi.step', $headers);
+        $this->assertEquals(0, $headers['zipi.step']);
+    }
+
+    /**
+     * @group 587
+     */
+    public function testExtractHeadersShouldAllowHeadersWithEmptyValues()
+    {
+        $response = $this->readResponse('response_587_empty');
+        $headers  = Zend_Http_Response::extractHeaders($response);
+
+        $this->assertArrayHasKey('imagetoolbar', $headers);
+        $this->assertEmpty($headers['imagetoolbar']);
+    }
+
+    /**
+     * @group 587
+     */
+    public function testExtractHeadersShouldAllowHeadersWithMissingValues()
+    {
+        $response = $this->readResponse('response_587_null');
+        $headers  = Zend_Http_Response::extractHeaders($response);
+
+        $this->assertArrayHasKey('imagetoolbar', $headers);
+        $this->assertEmpty($headers['imagetoolbar']);
+    }
 }

--- a/tests/Zend/Http/_files/response_587
+++ b/tests/Zend/Http/_files/response_587
@@ -1,0 +1,10 @@
+HTTP/1.1 200 OK
+Date: Wed, 05 Aug 2015 16:52:40 GMT
+Server: Apache
+Content-Length: 0
+zipi.step: 0
+Keep-Alive: timeout=15, max=100
+Connection: Keep-Alive
+Content-Type: text/html; charset=iso-8859-1
+
+

--- a/tests/Zend/Http/_files/response_587_empty
+++ b/tests/Zend/Http/_files/response_587_empty
@@ -1,0 +1,10 @@
+HTTP/1.1 200 OK
+Date: Wed, 05 Aug 2015 16:52:40 GMT
+Server: Apache
+Content-Length: 0
+Imagetoolbar: 
+Keep-Alive: timeout=15, max=100
+Connection: Keep-Alive
+Content-Type: text/html; charset=iso-8859-1
+
+

--- a/tests/Zend/Http/_files/response_587_null
+++ b/tests/Zend/Http/_files/response_587_null
@@ -1,0 +1,10 @@
+HTTP/1.1 200 OK
+Date: Wed, 05 Aug 2015 16:52:40 GMT
+Server: Apache
+Content-Length: 0
+Imagetoolbar:
+Keep-Alive: timeout=15, max=100
+Connection: Keep-Alive
+Content-Type: text/html; charset=iso-8859-1
+
+


### PR DESCRIPTION
In Version 1.12.13 is a bug which is not in Version 1.12.11.

If an HTTP header value is empty I get the Exception "Invalid header line detected" in Zend_Http_Response line 573

This happens because the regex in line 528 does not match if the value is empty.
As far as I know empty values are allowed in HTTP 1.1.

If I change the regex in line 528 from
"|^([\w-]+):\s*(.+)|s"
to
"|^([\w-]+):\s*(.*)|s"
it works fine. So just replacing the + by a *.

It would be nice if this could be fixed in the code, because this breaks existing code.
For me it broke the feed reader, which is fetching and parsing an RSS feed where one HTTP response header value is empty.

