### PR TITLE
Fix ZF-7570: forceIndex, useIndex, ignoreIndex methods on db select and join. 

### DIFF
--- a/tests/Zend/Db/Select/Pdo/MysqlTest.php
+++ b/tests/Zend/Db/Select/Pdo/MysqlTest.php
@@ -101,8 +101,7 @@ class Zend_Db_Select_Pdo_MysqlTest extends Zend_Db_Select_TestCommon
             ->join('zfbugs_products', "$products.$product_id = $bugs_products.$product_id", array())
             ->forceIndex('zfbugs_products', 'IX_this_index_does_not_exist_2');
 
-
-        $expected = 'SELECT `zfproducts`.* FROM `zfproducts` FORCE INDEX(IX_this_index_does_not_exist)' .
+        $expected = 'SELECT `p`.* FROM `zfproducts` AS `p` FORCE INDEX(IX_this_index_does_not_exist)' .
             "\n" . ' INNER JOIN `zfbugs_products` FORCE INDEX(IX_this_index_does_not_exist_2) ON `zfproducts`.`product_id` = `zfbugs_products`.`product_id`';
         $this->assertEquals($expected, $select->assemble(),
             'Select with join and force index failed');

--- a/tests/Zend/Db/Select/Pdo/MysqlTest.php
+++ b/tests/Zend/Db/Select/Pdo/MysqlTest.php
@@ -96,7 +96,7 @@ class Zend_Db_Select_Pdo_MysqlTest extends Zend_Db_Select_TestCommon
         $bugs_products = $this->_db->quoteIdentifier('zfbugs_products');
 
         $select = $this->_db->select()
-            ->from('zfproducts')
+            ->from(array('p'=>'zfproducts'))
             ->forceIndex('p', 'IX_this_index_does_not_exist')
             ->join('zfbugs_products', "$products.$product_id = $bugs_products.$product_id", array())
             ->forceIndex('zfbugs_products', 'IX_this_index_does_not_exist_2');

--- a/tests/Zend/Db/Select/Pdo/MysqlTest.php
+++ b/tests/Zend/Db/Select/Pdo/MysqlTest.php
@@ -51,9 +51,12 @@ class Zend_Db_Select_Pdo_MysqlTest extends Zend_Db_Select_TestCommon
     {
         $select = $this->_db->select();
         $select->from(array ('p' => 'product'))
-            ->forceIndex('IX_this_index_does_not_exist');
+            ->forceIndex('p', 'IX_this_index_does_not_exist');
 
         $expected = 'SELECT `p`.* FROM `product` AS `p` FORCE INDEX(IX_this_index_does_not_exist)';
+        $this->assertEquals($expected, $select->assemble(),
+            'Select with force index failed');
+        #Index should remain after first assemble
         $this->assertEquals($expected, $select->assemble(),
             'Select with force index failed');
     }
@@ -62,22 +65,28 @@ class Zend_Db_Select_Pdo_MysqlTest extends Zend_Db_Select_TestCommon
     {
         $select = $this->_db->select();
         $select->from(array ('p' => 'product'))
-            ->useIndex('IX_this_index_does_not_exist');
+            ->useIndex('p', 'IX_this_index_does_not_exist');
 
         $expected = 'SELECT `p`.* FROM `product` AS `p` USE INDEX(IX_this_index_does_not_exist)';
         $this->assertEquals($expected, $select->assemble(),
             'Select with use index failed');
+        #Index should remain after first assemble
+        $this->assertEquals($expected, $select->assemble(),
+            'Select with force index failed');
     }
 
     public function testSelectWithIgnoreIndex()
     {
         $select = $this->_db->select();
         $select->from(array ('p' => 'product'))
-            ->ignoreIndex('IX_this_index_does_not_exist');
+            ->ignoreIndex('p', 'IX_this_index_does_not_exist');
 
         $expected = 'SELECT `p`.* FROM `product` AS `p` IGNORE INDEX(IX_this_index_does_not_exist)';
         $this->assertEquals($expected, $select->assemble(),
             'Select with ignore index failed');
+        #Index should remain after first assemble
+        $this->assertEquals($expected, $select->assemble(),
+            'Select with force index failed');
     }
 
     public function testSelectWithJoinAndForceIndex()
@@ -88,12 +97,17 @@ class Zend_Db_Select_Pdo_MysqlTest extends Zend_Db_Select_TestCommon
 
         $select = $this->_db->select()
             ->from('zfproducts')
-            ->forceIndex('IX_this_index_does_not_exist')
-            ->join('zfbugs_products', "$products.$product_id = $bugs_products.$product_id", array());
+            ->forceIndex('p', 'IX_this_index_does_not_exist')
+            ->join('zfbugs_products', "$products.$product_id = $bugs_products.$product_id", array())
+            ->forceIndex('zfbugs_products', 'IX_this_index_does_not_exist_2');
+
 
         $expected = 'SELECT `zfproducts`.* FROM `zfproducts` FORCE INDEX(IX_this_index_does_not_exist)' .
-            "\n" . ' INNER JOIN `zfbugs_products` ON `zfproducts`.`product_id` = `zfbugs_products`.`product_id`';
+            "\n" . ' INNER JOIN `zfbugs_products` FORCE INDEX(IX_this_index_does_not_exist_2) ON `zfproducts`.`product_id` = `zfbugs_products`.`product_id`';
         $this->assertEquals($expected, $select->assemble(),
             'Select with join and force index failed');
+        #Index should remain after first assemble
+        $this->assertEquals($expected, $select->assemble(),
+            'Select with force index failed');
     }
 }


### PR DESCRIPTION
This PR is a replacement for #509.