### PR TITLE
Fix setting of CURLOPT_TIMEOUT

### DIFF
--- a/library/Zend/Http/Client/Adapter/Curl.php
+++ b/library/Zend/Http/Client/Adapter/Curl.php
@@ -228,10 +228,12 @@ class Zend_Http_Client_Adapter_Curl implements Zend_Http_Client_Adapter_Interfac
             curl_setopt($this->_curl, CURLOPT_CONNECTTIMEOUT, $this->_config['timeout']);
         }
 
-        if (defined('CURLOPT_TIMEOUT_MS')) {
-            curl_setopt($this->_curl, CURLOPT_TIMEOUT_MS, $this->_config['timeout'] * 1000);
-        } else {
-            curl_setopt($this->_curl, CURLOPT_TIMEOUT, $this->_config['timeout']);
+        if (array_key_exists('request_timeout', $this->_config)) {
+          if (defined('CURLOPT_TIMEOUT_MS')) {
+              curl_setopt($this->_curl, CURLOPT_TIMEOUT_MS, $this->_config['request_timeout'] * 1000);
+          } else {
+              curl_setopt($this->_curl, CURLOPT_TIMEOUT, $this->_config['request_timeout']);
+          }
         }
 
         // Set Max redirects


### PR DESCRIPTION
PR 405 assigned the 'timeout' config setting to CURLOPT_TIMEOUT in
addition to CURLOPT_CONNECTTIMEOUT. This commit changes this so that a
new config setting of 'request_timeout' is used to setting
CURLOPT_TIMEOUT.

Closes #582