### PR TITLE
Change default secure transport to TLS

### DIFF
--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -74,7 +74,7 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
      */
     protected $config = array(
         'persistent'    => false,
-        'ssltransport'  => 'ssl',
+        'ssltransport'  => 'tls',
         'sslcert'       => null,
         'sslpassphrase' => null,
         'sslusecontext' => false


### PR DESCRIPTION
Change default secure transport to TLS, because SSL is deprecated.
SSL disabled by default in Apache 2.2.30 and nginx 1.9.1.
After web server update code will no longer work.