### PR TITLE
Fixes #504 - Cannot parse huge documents in Zend_Dom_Query

### DIFF
--- a/library/Zend/Dom/Query.php
+++ b/library/Zend/Dom/Query.php
@@ -154,6 +154,9 @@ class Zend_Dom_Query
     {
         $this->_document = $document;
         $this->_docType  = self::DOC_DOM;
+        if (null !== $document->encoding) {
+            $this->setEncoding($document->encoding);
+        }
         return $this;
     }
 
@@ -211,7 +214,7 @@ class Zend_Dom_Query
     /**
      * Retrieve current document
      *
-     * @return string
+     * @return string|DOMDocument
      */
     public function getDocument()
     {
@@ -276,6 +279,7 @@ class Zend_Dom_Query
         switch ($type) {
             case self::DOC_DOM:
                 $domDoc = $this->_document;
+                $success = true;
                 break;
             case self::DOC_XML:
                 try {

--- a/library/Zend/Dom/Query.php
+++ b/library/Zend/Dom/Query.php
@@ -48,13 +48,14 @@ class Zend_Dom_Query
     /**#@+
      * Document types
      */
+    const DOC_DOM   = 'docDom';
     const DOC_XML   = 'docXml';
     const DOC_HTML  = 'docHtml';
     const DOC_XHTML = 'docXhtml';
     /**#@-*/
 
     /**
-     * @var string
+     * @var string|DOMDocument
      */
     protected $_document;
 
@@ -85,7 +86,7 @@ class Zend_Dom_Query
     /**
      * Constructor
      *
-     * @param null|string $document
+     * @param null|string|DOMDocument $document
      * @param null|string $encoding
      */
     public function __construct($document = null, $encoding = null)
@@ -119,12 +120,15 @@ class Zend_Dom_Query
     /**
      * Set document to query
      *
-     * @param  string $document
+     * @param  string|DOMDocument $document
      * @param  null|string $encoding Document encoding
      * @return Zend_Dom_Query
      */
     public function setDocument($document, $encoding = null)
     {
+        if ($document instanceof DOMDocument) {
+            return $this->setDocumentDom($document);
+        }
         if (0 === strlen($document)) {
             return $this;
         }
@@ -140,6 +144,17 @@ class Zend_Dom_Query
             return $this->setDocumentXhtml($document, $encoding);
         }
         return $this->setDocumentHtml($document, $encoding);
+    }
+
+    /**
+     * @param DOMDocument $document
+     * @param string $encoding
+     */
+    public function setDocumentDom(DOMDocument $document)
+    {
+        $this->_document = $document;
+        $this->_docType  = self::DOC_DOM;
+        return $this;
     }
 
     /**
@@ -259,6 +274,9 @@ class Zend_Dom_Query
         }
         $type   = $this->getDocumentType();
         switch ($type) {
+            case self::DOC_DOM:
+                $domDoc = $this->_document;
+                break;
             case self::DOC_XML:
                 try {
                     $domDoc = Zend_Xml_Security::scan($document, $domDoc);

--- a/tests/Zend/Dom/QueryTest.php
+++ b/tests/Zend/Dom/QueryTest.php
@@ -240,7 +240,7 @@ class Zend_Dom_QueryTest extends PHPUnit_Framework_TestCase
 </foo>
 EOF;
         $document = new DOMDocument();
-        $document->loadXML($xml, LIBXML_PARSEHUGE);
+        $document->loadXML($xml, 524288 /* LIBXML_PARSEHUGE */);
         $this->query->setDocument($document);
         $test = $this->query->query('.baz');
         $this->assertTrue($test instanceof Zend_Dom_Query_Result);

--- a/tests/Zend/Dom/QueryTest.php
+++ b/tests/Zend/Dom/QueryTest.php
@@ -143,6 +143,8 @@ class Zend_Dom_QueryTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(Zend_Dom_Query::DOC_XML, $this->query->getDocumentType());
         $this->query->setDocument('<html><body></body></html>');
         $this->assertEquals(Zend_Dom_Query::DOC_HTML, $this->query->getDocumentType());
+        $this->query->setDocument(new DOMDocument());
+        $this->assertEquals(Zend_Dom_Query::DOC_DOM, $this->query->getDocumentType());
     }
 
     public function testQueryingWithoutRegisteringDocumentShouldThrowException()
@@ -227,6 +229,18 @@ class Zend_Dom_QueryTest extends PHPUnit_Framework_TestCase
         $this->loadHtml();
         $result = $this->query->queryXpath('//li[contains(@dojotype, "bar")]');
         $this->assertEquals(2, count($result), $result->getXpathQuery());
+    }
+
+    public function testQueryOnDomDocument()
+    {
+        $document = new DOMDocument('1.0', 'utf-8');
+        $document->loadHTML($this->getHtml(), LIBXML_PARSEHUGE);
+        $this->query->setDocument($document);
+        $test = $this->query->query('.foo');
+        $this->assertTrue($test instanceof Zend_Dom_Query_Result);
+        $testDocument = $test->getDocument();
+        $this->assertTrue($testDocument instanceof DOMDocument);
+        $this->assertEquals('utf-8', $testDocument->encoding);
     }
 
     /**

--- a/tests/Zend/Dom/QueryTest.php
+++ b/tests/Zend/Dom/QueryTest.php
@@ -233,14 +233,20 @@ class Zend_Dom_QueryTest extends PHPUnit_Framework_TestCase
 
     public function testQueryOnDomDocument()
     {
-        $document = new DOMDocument('1.0', 'utf-8');
-        $document->loadHTML($this->getHtml(), LIBXML_PARSEHUGE);
+        $xml = <<<EOF
+<?xml version="1.0" encoding="UTF-8" ?>
+<foo>
+    <bar class="baz"/>
+</foo>
+EOF;
+        $document = new DOMDocument();
+        $document->loadXML($xml, LIBXML_PARSEHUGE);
         $this->query->setDocument($document);
-        $test = $this->query->query('.foo');
+        $test = $this->query->query('.baz');
         $this->assertTrue($test instanceof Zend_Dom_Query_Result);
         $testDocument = $test->getDocument();
         $this->assertTrue($testDocument instanceof DOMDocument);
-        $this->assertEquals('utf-8', $testDocument->encoding);
+        $this->assertEquals('UTF-8', $testDocument->encoding);
     }
 
     /**

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -4,10 +4,10 @@
     </testsuite>
 
     <!-- Enable this for proper unit testing code coverage reports
+    -->
     <filter>
         <whitelist>
             <directory suffix=".php">../library/Zend</directory>
         </whitelist>
     </filter>
-    -->
 </phpunit>

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -4,10 +4,10 @@
     </testsuite>
 
     <!-- Enable this for proper unit testing code coverage reports
-    -->
     <filter>
         <whitelist>
             <directory suffix=".php">../library/Zend</directory>
         </whitelist>
     </filter>
+    -->
 </phpunit>


### PR DESCRIPTION
A new document type has been added to Zend_Dom_Query, it's called 'Dom' and means that the document setter received a DOMDocument instance instead of a string. Therefor the getter will also return the instance. In the queryXpath method there will be no additional parsing will be done.

I needed this to give the LIBXML_PARSEHUGE option to loadHTML() and recognize that it would've been a way to implement these options as a third information on the query class (much like encoding). But i'd found it to be complicating the whole scenario. Also i like to work with objects so injecting a DOMDocument should be totally fine.