### PR TITLE
add doccomments to Zend_Log covering its magic methods

### DIFF
--- a/library/Zend/Log.php
+++ b/library/Zend/Log.php
@@ -25,6 +25,15 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @version    $Id$
+ *
+ * @method emerg(string $message)
+ * @method alert(string $message)
+ * @method crit(string $message)
+ * @method err(string $message)
+ * @method warn(string $message)
+ * @method notice(string $message)
+ * @method info(string $message)
+ * @method debug(string $message)
  */
 class Zend_Log
 {


### PR DESCRIPTION
I find this useful in my IDE (at some point someone had tried to call `$log->error` instead of `$log->err`). This change simply highlights those issues in decent editors.