### PR TITLE
Pass raw headers from imap storage as "raw" when creating a message

### DIFF
--- a/library/Zend/Mail/Storage/Imap.php
+++ b/library/Zend/Mail/Storage/Imap.php
@@ -170,7 +170,7 @@ class Zend_Mail_Storage_Imap extends Zend_Mail_Storage_Abstract
             $flags[] = isset(self::$_knownFlags[$flag]) ? self::$_knownFlags[$flag] : $flag;
         }
 
-        return new $this->_messageClass(array('handler' => $this, 'id' => $id, 'headers' => $header, 'flags' => $flags));
+        return new $this->_messageClass(array('handler' => $this, 'id' => $id, 'raw' => $header, 'flags' => $flags));
     }
 
     /*


### PR DESCRIPTION
Due to the changes related to [ZF2015-04][1], some messages that are read from imap throw an "Invalid header value detected" exception.

`Zend_Mail_Storage_Imap::getMessage()` instantiates a new `Zend_Mail_Message` with an array of parameters. When these parameters contain the key `raw`, all occurrences of `\n` _not_ preceded with `\r` are replaced with `\r\n` in its value.

Next `Zend_Mail_Part` will use `Zend_Mime_Decode::splitMessage` to turn the string into an array of headers, which is later validated.

**But:**

`Zend_Mail_Storage_Imap::getMessage()` doesn't use the key `raw`, but uses `headers` in stead. In this case the replace of `\n` to `\r\n` doesn't happen. The result is that headers like these will throw the "Invalid header value detected" exception:

```
Content-Disposition: attachment; filename=
	"=?iso-8859-1?Q?hiding-real-file-name?="
```

The `\n` will be seen as invalid.

**Fix:**

This PR fixes this issue by using `raw` in stead of `headers`.

[1]: http://framework.zend.com/security/advisory/ZF2015-04