### PR TITLE
Automatically pass an x-request-id header in HTTP requests if UNIQUE_ID value is set

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -1204,6 +1204,12 @@ class Zend_Http_Client
             }
         }
 
+        // Pass an x-request-id value if UNQIUE_ID env var is set to help track requests between application boundaries
+        $uniqueId = getenv('UNIQUE_ID');
+        if ($uniqueId && !isset($this->headers['x-request-id'])) {
+            $headers[] = "x-request-id: {$uniqueId}";
+        }
+
         // Set the Accept-encoding header if not set - depending on whether
         // zlib is available or not.
         if (! isset($this->headers['accept-encoding'])) {


### PR DESCRIPTION
I have found this to be useful in order to help trace how requests are sent to various internal microservices within our system. I'd like to see this, or something like, it make it into the framework.