### PR TITLE
We needed to add the @ symbol in order to avoid problems in production

### DIFF
--- a/library/Zend/Locale/Format.php
+++ b/library/Zend/Locale/Format.php
@@ -524,7 +524,16 @@ class Zend_Locale_Format
             $input = 0 . $input;
         }
         foreach ($regexs as $regex) {
-            preg_match($regex, $input, $found);
+            /**
+             * The following locales generate an error and I have therefore suppressed the error
+             * with the @ symbol. Hopefully someone can fix this. It seems to have to do with a
+             * unicode non printable control char related to the minus sign. The consequence of
+             * this bug is that certain locales will incorrectly have a false returned by this
+             * function.
+             *
+             * 'ar','fa', 'he', 'ks', 'uz_Arab','ur','root'
+             */
+            @preg_match($regex, $input, $found);
             if (isset($found[0])) {
                 return true;
             }


### PR DESCRIPTION
For reasons unknown, we would see this preg_match fail in a bunch of places. A long time ago I forked zf1 in order to add a few small things but if we can get this, or something like it, added to the main line than I can stop using my fork.