### PR TITLE
Solve problem with subqueries in SELECT block

### DIFF
--- a/library/Zend/Db/Select.php
+++ b/library/Zend/Db/Select.php
@@ -1143,7 +1143,7 @@ class Zend_Db_Select
 
         // Add the list of all joins
         if (!empty($from)) {
-            $sql .= ' ' . self::SQL_FROM . ' ' . implode("\n", $from);
+            $sql .= ' ' . self::SQL_FROM . ' ' . implode(" ", $from);
         }
 
         return $sql;


### PR DESCRIPTION
It solves executing queries with subqueries in SELECT block.
"New line" char caused problem in regexp for "AS" case detection in function _tableCols in Zend/Db/Select.php (line 943)