### PR TITLE
Fixed the null byte test for Zend_Db_Adapter_Pdo

### DIFF
--- a/tests/Zend/Db/Adapter/Pdo/TestCommon.php
+++ b/tests/Zend/Db/Adapter/Pdo/TestCommon.php
@@ -98,6 +98,6 @@ abstract class Zend_Db_Adapter_Pdo_TestCommon extends Zend_Db_Adapter_TestCommon
     {
         $string = "1\0";
         $value  = $this->_db->quote($string);
-        $this->assertEquals("'1\\000'", $value);
+        $this->assertNotContains("\0", $value);
     }
 }


### PR DESCRIPTION
This PR fixes the test issue with null byte for Zend_Db_Adapter_Pdo.