### PR TITLE
Add decimalFormats definition in bs.xml of Zend_Locale

### DIFF
--- a/library/Zend/Locale/Data/bs.xml
+++ b/library/Zend/Locale/Data/bs.xml
@@ -3129,6 +3129,13 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<decimal>,</decimal>
 			<group>.</group>
 		</symbols>
+		<decimalFormats numberSystem="latn">
+			<decimalFormatLength>
+				<decimalFormat>
+					<pattern>#,##0.###</pattern>
+				</decimalFormat>
+			</decimalFormatLength>
+		</decimalFormats>
 		<currencies>
 			<!-- This just had confirmed data for "XXX".
 				 Fill in the other translations from data in sr_Latn.


### PR DESCRIPTION
I tried to use  Zend_Locale_Format::getNumber() with the locale bs_BA. Unfortuneately it doesn't accept any number format.

Therefore I added a decimalFormats definition in the bs.xml - now It work's for my use-case. I hope that this is the right way to do this.