### PR TITLE
ZF2015-09: The Zend_Crypt_MathTest should run on PHP 5.2/5.3

### DIFF
--- a/tests/Zend/Crypt/MathTest.php
+++ b/tests/Zend/Crypt/MathTest.php
@@ -80,10 +80,10 @@ class Zend_Crypt_MathTest extends PHPUnit_Framework_TestCase
 
     public static function provideRandInt()
     {
-        return [
-            [2, 1, 10000, 100, 0.9, 1.1, false],
-            [2, 1, 10000, 100, 0.8, 1.2, true]
-        ];
+        return array(
+            array(2, 1, 10000, 100, 0.9, 1.1, false),
+            array(2, 1, 10000, 100, 0.8, 1.2, true)
+        );
     }
 
     /**


### PR DESCRIPTION
This should make the Zend_Crypt_MathTest run on PHP 5.2/5.3

ping @weierophinney 