### PR TITLE
Skip Zend_Soap tests on Travis with PHP 5.4.37 because of segfaults

### DIFF
--- a/tests/Zend/Soap/AllTests.php
+++ b/tests/Zend/Soap/AllTests.php
@@ -51,6 +51,12 @@ class Zend_Soap_AllTests
     {
         $suite = new PHPUnit_Framework_TestSuite('Zend Framework - Zend_Soap');
 
+        //early exit because of segfault in this specific version
+        //https://github.com/zendframework/zf1/issues/650
+        if (getenv('TRAVIS') && version_compare(PHP_VERSION, '5.4.37', '=')) {
+            return $suite;
+        }
+
         $suite->addTestSuite('Zend_Soap_ClientTest');
         $suite->addTestSuite('Zend_Soap_ServerTest');
         $suite->addTestSuite('Zend_Soap_WsdlTest');


### PR DESCRIPTION
I think it is better to have tests green, so the proper attention will be paid to any failures.

Closes #650 

