### PR TITLE
Error: trim() expects parameter 1 to be string, array given - library…

### DIFF
--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -1122,6 +1122,11 @@ class Zend_Http_Client
             // If we got redirected, look for the Location header
             if ($response->isRedirect() && ($location = $response->getHeader('location'))) {
 
+                // Location header can be returned as an array
+                if (is_array($location)) {
+                    $location = reset($location);
+                }
+
                 // Avoid problems with buggy servers that add whitespace at the
                 // end of some headers (See ZF-11283)
                 $location = trim($location);


### PR DESCRIPTION
…/Zend/Http/Client.php:1127

We have seen occasions where the location header is returned as an array, but the code assumes we'll be dealing with a string, so check for that and reset the array where applicable.