### PR TITLE
Fix for 655 issue

### DIFF
--- a/library/Zend/Db/Adapter/Pdo/Abstract.php
+++ b/library/Zend/Db/Adapter/Pdo/Abstract.php
@@ -292,8 +292,6 @@ abstract class Zend_Db_Adapter_Pdo_Abstract extends Zend_Db_Adapter_Abstract
         if (is_int($value) || is_float($value)) {
             return $value;
         }
-        // Fix for null-byte injection
-        $value = addcslashes($value, "\000\032");
         $this->_connect();
         return $this->_connection->quote($value);
     }

--- a/library/Zend/Db/Adapter/Pdo/Mssql.php
+++ b/library/Zend/Db/Adapter/Pdo/Mssql.php
@@ -420,4 +420,19 @@ class Zend_Db_Adapter_Pdo_Mssql extends Zend_Db_Adapter_Pdo_Abstract
             return null;
         }
     }
+
+    /**
+     * Quote a raw string.
+     *
+     * @param string $value     Raw string
+     * @return string           Quoted string
+     */
+    protected function _quote($value)
+    {
+        if (!is_int($value) && !is_float($value)) {
+            // Fix for null-byte injection
+            $value = addcslashes($value, "\000\032");
+        }
+        return parent::_quote($value);
+    }
 }

--- a/library/Zend/Db/Adapter/Pdo/Sqlite.php
+++ b/library/Zend/Db/Adapter/Pdo/Sqlite.php
@@ -294,4 +294,18 @@ class Zend_Db_Adapter_Pdo_Sqlite extends Zend_Db_Adapter_Pdo_Abstract
         return $sql;
     }
 
+    /**
+     * Quote a raw string.
+     *
+     * @param string $value     Raw string
+     * @return string           Quoted string
+     */
+    protected function _quote($value)
+    {
+        if (!is_int($value) && !is_float($value)) {
+            // Fix for null-byte injection
+            $value = addcslashes($value, "\000\032");
+        }
+        return parent::_quote($value);
+    }
 }

--- a/tests/Zend/Db/Adapter/Pdo/MssqlTest.php
+++ b/tests/Zend/Db/Adapter/Pdo/MssqlTest.php
@@ -361,6 +361,17 @@ class Zend_Db_Adapter_Pdo_MssqlTest extends Zend_Db_Adapter_Pdo_TestCommon
         $this->assertArrayHasKey('product_name', $productsTableInfo);
     }
 
+    /**
+     * test that quote() escapes null byte character
+     * in a string.
+     */
+    public function testAdapterQuoteNullByteCharacter()
+    {
+        $string = "1\0";
+        $value  = $this->_db->quote($string);
+        $this->assertEquals("'1\\000'", $value);
+    }
+
     public function getDriver()
     {
         return 'Pdo_Mssql';

--- a/tests/Zend/Db/Adapter/Pdo/MysqlTest.php
+++ b/tests/Zend/Db/Adapter/Pdo/MysqlTest.php
@@ -315,7 +315,17 @@ class Zend_Db_Adapter_Pdo_MysqlTest extends Zend_Db_Adapter_Pdo_TestCommon
         $adapter = new ZendTest_Db_Adapter_Pdo_Mysql(array('dbname' => 'foo', 'charset' => 'XYZ', 'username' => 'bar', 'password' => 'foo'));
         $this->assertEquals('mysql:dbname=foo;charset=XYZ', $adapter->_dsn());
     }
-    
+
+    /**
+     * Test that quote() does not alter binary data
+     */
+    public function testBinaryQuoteWithNulls()
+    {
+        $binary = pack("xxx");
+        $value  = $this->_db->quote($binary);
+        $this->assertEquals('\'\0\0\0\'', $value);
+    }
+
     public function getDriver()
     {
         return 'Pdo_Mysql';
@@ -330,4 +340,3 @@ class ZendTest_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql
         return parent::_dsn();
     }
 }
-

--- a/tests/Zend/Db/Adapter/Pdo/SqliteTest.php
+++ b/tests/Zend/Db/Adapter/Pdo/SqliteTest.php
@@ -247,4 +247,15 @@ class Zend_Db_Adapter_Pdo_SqliteTest extends Zend_Db_Adapter_Pdo_TestCommon
         $this->assertTrue($stmt instanceof $stmtClass,
             'Expecting object of type ' . $stmtClass . ', got ' . get_class($stmt));
     }
+
+    /**
+     * test that quote() escapes null byte character
+     * in a string.
+     */
+    public function testAdapterQuoteNullByteCharacter()
+    {
+        $string = "1\0";
+        $value  = $this->_db->quote($string);
+        $this->assertEquals("'1\\000'", $value);
+    }
 }


### PR DESCRIPTION
This PR fixes the #655 issue for MySQL. I removed the filter of null-bytes from quote() in Pdo\Abstract and I moved in MsSQL and Sqlite for [ZF2015-08](http://framework.zend.com/security/advisory/ZF2015-08). This should remove the double quotes of null-bytes for MySQL. I provided [this test](https://github.com/ezimuel/zf1/blob/fix/655/tests/Zend/Db/Adapter/Pdo/MysqlTest.php#L322-L327) for MySQL. 
Waiting feedback from @Thomas-Gelf, @moshevds and others.