### PR TITLE
setEncoding fails empty value

### DIFF
--- a/library/Zend/Validate/StringLength.php
+++ b/library/Zend/Validate/StringLength.php
@@ -207,7 +207,7 @@ class Zend_Validate_StringLength extends Zend_Validate_Abstract
             } else {
                 $result = ini_set('default_charset', $encoding);
             }
-            if (!$result) {
+            if ($result === false) {
                 require_once 'Zend/Validate/Exception.php';
                 throw new Zend_Validate_Exception('Given encoding not supported on this OS!');
             }


### PR DESCRIPTION
ini_set will return old value and will always thrown an error when empty. There it needs to be checked on a false bool in case not exists. ini_set will return false on failure