### PR TITLE
Problem with module in upper

### DIFF
--- a/library/Zend/Controller/Dispatcher/Standard.php
+++ b/library/Zend/Controller/Dispatcher/Standard.php
@@ -394,7 +394,7 @@ class Zend_Controller_Dispatcher_Standard extends Zend_Controller_Dispatcher_Abs
         $module = $request->getModuleName();
         if ($this->isValidModule($module)) {
             $this->_curModule    = $module;
-            $this->_curDirectory = $controllerDirs[$module];
+            $this->_curDirectory = $controllerDirs[strtolower($module)];
         } elseif ($this->isValidModule($this->_defaultModule)) {
             $request->setModuleName($this->_defaultModule);
             $this->_curModule    = $this->_defaultModule;


### PR DESCRIPTION
With a default router /:module/:controller/:action/:params all works fine. But for example in URL request

/MODULE/controller/action (module in upper) get error Notice: Undefined index: MODULE in \vendor\zendframework\zendframework1\library\Zend\Controller\Dispatcher\Standard.php on line 397

In $controllerDirs all key are in lowercase

Other solution modify the Request Abstract Class

```php

abstract class Zend_Controller_Request_Abstract {

/**
     * Retrieve the module name
     *
     * @return string
     */
    public function getModuleName()
    {
        if (null === $this->_module) {
            $this->setModuleName($this->getParam($this->getModuleKey()));
        }

        return $this->_module;
    }

    /**
     * Set the module name to use
     *
     * @param string $value
     * @return Zend_Controller_Request_Abstract
     */
    public function setModuleName($value)
    {
        $this->_module = strtolower($value);
        return $this;
    }
}

```