### PR TITLE
setCharset is a real method and so the doccomment is not required

### DIFF
--- a/library/Zend/View/Helper/HeadMeta.php
+++ b/library/Zend/View/Helper/HeadMeta.php
@@ -41,7 +41,6 @@ require_once 'Zend/View/Helper/Placeholder/Container/Standalone.php';
  * @method $this prependHttpEquiv($keyValue, $content, $conditionalHttpEquiv)
  * @method $this prependName($keyValue, $content, $conditionalName)
  * @method $this prependProperty($property, $content, $modifiers)
- * @method $this setCharset($charset)
  * @method $this setHttpEquiv($keyValue, $content, $modifiers)
  * @method $this setName($keyValue, $content, $modifiers)
  * @method $this setProperty($property, $content, $modifiers)


### PR DESCRIPTION
`setCharset` is covered by a concrete implementation in the class and not part of the __call magic method. 

It therefore doesn't need the @method doccomment declaration.

This change prevents IDEs such as PhpStorm from picking it up as an error.

---

_Have sent in a CLA - I know this is a small change but we have a long-term ZF1 project at work so I anticipate more meaningful PRs in the future!_
