### PR TITLE
Fix pcre seg fault in Zend_Db_Statement

### DIFF
--- a/library/Zend/Db/Statement.php
+++ b/library/Zend/Db/Statement.php
@@ -191,13 +191,13 @@ abstract class Zend_Db_Statement implements Zend_Db_Statement_Interface
         if (!empty($q)) {
             $escapeChar = preg_quote($escapeChar);
             // this segfaults only after 65,000 characters instead of 9,000
-            $sql = preg_replace("/$q([^$q{$escapeChar}]*|($qe)*)*$q/s", '', $sql);
+            $sql = preg_replace("/$q(?:[^$q{$escapeChar}]*|($qe)*)*$q/s", '', $sql);
         }
         
         // get a version of the SQL statement with all quoted
         // values and delimited identifiers stripped out
         // remove "foo\"bar"
-        $sql = preg_replace("/\"(\\\\\"|[^\"])*\"/Us", '', $sql);
+        $sql = preg_replace("/\"(?:\\\\\"|[^\"])*\"/Us", '', $sql);
 
         // get the character for delimited id quotes,
         // this is usually " but in MySQL is `
@@ -209,7 +209,7 @@ abstract class Zend_Db_Statement implements Zend_Db_Statement_Interface
         $de = substr($de, 1, 2);
         $de = preg_quote($de);
         // Note: $de and $d where never used..., now they are:
-        $sql = preg_replace("/$d($de|\\\\{2}|[^$d])*$d/Us", '', $sql);
+        $sql = preg_replace("/$d(?:$de|\\\\{2}|[^$d])*$d/Us", '', $sql);
         return $sql;
     }
 


### PR DESCRIPTION
We encountered some segmentation faults on long queries (>10.000 characters) containing double quotes at this place. Marking the capture as ignored fixed it. After all it is not used anyway.