### PR TITLE
In case $maxLifetime is null, the $lifetime will never be used

### DIFF
--- a/library/Zend/Cache/Backend/TwoLevels.php
+++ b/library/Zend/Cache/Backend/TwoLevels.php
@@ -501,7 +501,7 @@ class Zend_Cache_Backend_TwoLevels extends Zend_Cache_Backend implements Zend_Ca
             $fastLifetime = (int) ceil($lifetime / (11 - $priority));
         }
 
-        if ($maxLifetime >= 0 && $fastLifetime > $maxLifetime) {
+        if ($maxLifetime > 0 && $fastLifetime > $maxLifetime) {
             return $maxLifetime;
         }
 


### PR DESCRIPTION
In case $maxLifetime is null (which it is by default), the $lifetime will never be used and null will always be returned.

Fixes issue zendframework/zf1#503.