### PR TITLE
Always return true in session handler destroy method

### DIFF
--- a/library/Zend/Session/SaveHandler/DbTable.php
+++ b/library/Zend/Session/SaveHandler/DbTable.php
@@ -365,17 +365,13 @@ class Zend_Session_SaveHandler_DbTable
      * Destroy session
      *
      * @param string $id
-     * @return boolean
+     * @return true
      */
     public function destroy($id)
     {
-        $return = false;
+        $this->delete($this->_getPrimary($id, self::PRIMARY_TYPE_WHERECLAUSE));
 
-        if ($this->delete($this->_getPrimary($id, self::PRIMARY_TYPE_WHERECLAUSE))) {
-            $return = true;
-        }
-
-        return $return;
+        return true;
     }
 
     /**


### PR DESCRIPTION
For PHP 7 compatibility. See this change:
http://php.net/manual/de/migration70.incompatible.php#migration70.incompatible.other.fixes-custom-session-handler