### PR TITLE
Fix Zend/VersionTest.php for versions 1.12.20 & 1.12.21

### DIFF
--- a/tests/Zend/VersionTest.php
+++ b/tests/Zend/VersionTest.php
@@ -55,7 +55,7 @@ class Zend_VersionTest extends PHPUnit_Framework_TestCase
         // unit test breaks if ZF version > 1.x
         for ($i=0; $i <= 1; $i++) {
             for ($j=0; $j <= 12; $j++) {
-                for ($k=0; $k < 20; $k++) {
+                for ($k=0; $k <= 21; $k++) {
                     foreach (array('dev', 'pr', 'PR', 'alpha', 'a1', 'a2', 'beta', 'b1', 'b2', 'RC', 'RC1', 'RC2', 'RC3', '', 'pl1', 'PL1') as $rel) {
                         $ver = "$i.$j.$k$rel";
                         $normalizedVersion = strtolower(Zend_Version::VERSION);


### PR DESCRIPTION
Hello,

just fixing the UnitTests to work for latest release versions 1.12.20 & 1.12.21 so travis stop marking build as failed.