### PR TITLE
Fix to restore error_handler before throw exception

### DIFF
--- a/library/Zend/Config/Xml.php
+++ b/library/Zend/Config/Xml.php
@@ -106,12 +106,14 @@ class Zend_Config_Xml extends Zend_Config
         } else {
             try {
                 if (!$config = Zend_Xml_Security::scanFile($xml)) {
+                    restore_error_handler();
                     require_once 'Zend/Config/Exception.php';
                     throw new Zend_Config_Exception(
                         "Error failed to load $xml file"
                     );
                 }
             } catch (Zend_Xml_Exception $e) {
+                restore_error_handler();
                 require_once 'Zend/Config/Exception.php';
                 throw new Zend_Config_Exception(
                     $e->getMessage()


### PR DESCRIPTION
When for whatever reason we use a "navigator.xml" file and it doesn't exists, an exception is throw and still with the `error_handler`  as `_loadFileErrorHandler` instead of our `error_handler`. 

This caused some bugs on our application.

Our Solution/workaround: Catch that exception; restore error_handler; continue.
